### PR TITLE
Refactor output HDF5 files

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,13 +14,13 @@ jobs:
         run: |
           wget -qO- get.nextflow.io | bash
           sudo mv nextflow /usr/local/bin/
-    - name: Free disk space
-      run: |
-        sudo swapoff -a
-        sudo rm -f /swapfile
-        sudo apt clean
-        docker rmi $(docker image ls -aq)
-        df -h
+      - name: Free disk space
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          docker rmi $(docker image ls -aq)
+          df -h
       - name:  Run geneshot
         run: |
           NXF_VER=20.01.0 nextflow run main.nf -c nextflow.config.sample -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --formula "label1 + label2" --distance_threshold 0.5 -w work/ --eggnog_db false --eggnog_dmnd false --taxonomic_dmnd false -with-docker ubuntu:latest
@@ -35,13 +35,13 @@ jobs:
         run: |
           wget -qO- get.nextflow.io | bash
           sudo mv nextflow /usr/local/bin/
-    - name: Free disk space
-      run: |
-        sudo swapoff -a
-        sudo rm -f /swapfile
-        sudo apt clean
-        docker rmi $(docker image ls -aq)
-        df -h
+      - name: Free disk space
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          docker rmi $(docker image ls -aq)
+          df -h
       - name:  Run geneshot
         run: |
           NXF_VER=20.01.0 nextflow run main.nf -c nextflow.config.sample -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --formula "label1 + label2" --distance_threshold 0.5 -w work/ --noannot -with-docker ubuntu:latest --nopreprocess
@@ -56,13 +56,13 @@ jobs:
         run: |
           wget -qO- get.nextflow.io | bash
           sudo mv nextflow /usr/local/bin/
-    - name: Free disk space
-      run: |
-        sudo swapoff -a
-        sudo rm -f /swapfile
-        sudo apt clean
-        docker rmi $(docker image ls -aq)
-        df -h
+      - name: Free disk space
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          docker rmi $(docker image ls -aq)
+          df -h
       - name:  Run geneshot
         run: |
           NXF_VER=20.01.0 nextflow run main.nf -c nextflow.config.sample -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --distance_threshold 0.5 -w work/ --noannot -with-docker ubuntu:latest
@@ -77,13 +77,13 @@ jobs:
         run: |
           wget -qO- get.nextflow.io | bash
           sudo mv nextflow /usr/local/bin/
-    - name: Free disk space
-      run: |
-        sudo swapoff -a
-        sudo rm -f /swapfile
-        sudo apt clean
-        docker rmi $(docker image ls -aq)
-        df -h
+      - name: Free disk space
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          docker rmi $(docker image ls -aq)
+          df -h
       - name:  Run geneshot
         run: |
           NXF_VER=20.01.0 nextflow run main.nf -c nextflow.config.sample -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --formula "label1 + label2" --distance_threshold 0.5 -w work/ --noannot -with-docker ubuntu:latest --gene_fasta data/genes.fasta.2.gz
@@ -98,13 +98,13 @@ jobs:
         run: |
           wget -qO- get.nextflow.io | bash
           sudo mv nextflow /usr/local/bin/
-    - name: Free disk space
-      run: |
-        sudo swapoff -a
-        sudo rm -f /swapfile
-        sudo apt clean
-        docker rmi $(docker image ls -aq)
-        df -h
+      - name: Free disk space
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          docker rmi $(docker image ls -aq)
+          df -h
       - name:  Run geneshot
         run: |
           NXF_VER=20.01.0 nextflow run main.nf -c nextflow.config.sample -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --formula "label1 + label2" --distance_threshold 0.5 -w work/ -with-docker ubuntu:latest --gene_fasta data/genes.fasta.2.gz --eggnog_dmnd https://github.com/eggnogdb/eggnog-mapper/raw/master/test/test_db.dmnd --eggnog_db https://github.com/eggnogdb/eggnog-mapper/raw/master/test/test_eggnog.db --taxonomic_dmnd false

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,6 +14,13 @@ jobs:
         run: |
           wget -qO- get.nextflow.io | bash
           sudo mv nextflow /usr/local/bin/
+    - name: Free disk space
+      run: |
+        sudo swapoff -a
+        sudo rm -f /swapfile
+        sudo apt clean
+        docker rmi $(docker image ls -aq)
+        df -h
       - name:  Run geneshot
         run: |
           NXF_VER=20.01.0 nextflow run main.nf -c nextflow.config.sample -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --formula "label1 + label2" --distance_threshold 0.5 -w work/ --eggnog_db false --eggnog_dmnd false --taxonomic_dmnd false -with-docker ubuntu:latest
@@ -28,6 +35,13 @@ jobs:
         run: |
           wget -qO- get.nextflow.io | bash
           sudo mv nextflow /usr/local/bin/
+    - name: Free disk space
+      run: |
+        sudo swapoff -a
+        sudo rm -f /swapfile
+        sudo apt clean
+        docker rmi $(docker image ls -aq)
+        df -h
       - name:  Run geneshot
         run: |
           NXF_VER=20.01.0 nextflow run main.nf -c nextflow.config.sample -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --formula "label1 + label2" --distance_threshold 0.5 -w work/ --noannot -with-docker ubuntu:latest --nopreprocess
@@ -42,6 +56,13 @@ jobs:
         run: |
           wget -qO- get.nextflow.io | bash
           sudo mv nextflow /usr/local/bin/
+    - name: Free disk space
+      run: |
+        sudo swapoff -a
+        sudo rm -f /swapfile
+        sudo apt clean
+        docker rmi $(docker image ls -aq)
+        df -h
       - name:  Run geneshot
         run: |
           NXF_VER=20.01.0 nextflow run main.nf -c nextflow.config.sample -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --distance_threshold 0.5 -w work/ --noannot -with-docker ubuntu:latest
@@ -56,6 +77,13 @@ jobs:
         run: |
           wget -qO- get.nextflow.io | bash
           sudo mv nextflow /usr/local/bin/
+    - name: Free disk space
+      run: |
+        sudo swapoff -a
+        sudo rm -f /swapfile
+        sudo apt clean
+        docker rmi $(docker image ls -aq)
+        df -h
       - name:  Run geneshot
         run: |
           NXF_VER=20.01.0 nextflow run main.nf -c nextflow.config.sample -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --formula "label1 + label2" --distance_threshold 0.5 -w work/ --noannot -with-docker ubuntu:latest --gene_fasta data/genes.fasta.2.gz
@@ -70,6 +98,13 @@ jobs:
         run: |
           wget -qO- get.nextflow.io | bash
           sudo mv nextflow /usr/local/bin/
+    - name: Free disk space
+      run: |
+        sudo swapoff -a
+        sudo rm -f /swapfile
+        sudo apt clean
+        docker rmi $(docker image ls -aq)
+        df -h
       - name:  Run geneshot
         run: |
           NXF_VER=20.01.0 nextflow run main.nf -c nextflow.config.sample -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --formula "label1 + label2" --distance_threshold 0.5 -w work/ -with-docker ubuntu:latest --gene_fasta data/genes.fasta.2.gz --eggnog_dmnd https://github.com/eggnogdb/eggnog-mapper/raw/master/test/test_db.dmnd --eggnog_db https://github.com/eggnogdb/eggnog-mapper/raw/master/test/test_eggnog.db --taxonomic_dmnd false

--- a/main.nf
+++ b/main.nf
@@ -344,7 +344,8 @@ workflow {
     // Run the alignment-based analysis steps (in modules/alignment.nf)
     alignment_wf(
         gene_fasta,
-        combineReads.out
+        combineReads.out,
+        params.output_prefix
     )
 
     // ########################

--- a/main.nf
+++ b/main.nf
@@ -191,15 +191,13 @@ include readTaxonomy from './modules/general'
 include addEggnogResults from './modules/general'
 include addCorncobResults from './modules/general'
 include addTaxResults from './modules/general'
-include makeSummaryHDF from './modules/general' params(
-    output_prefix: params.output_prefix
-)
 include repackHDF as repackFullHDF from './modules/general'
-include repackHDF as repackSummaryHDF from './modules/general'
+include repackHDF as repackDetailedHDF from './modules/general'
 
 // Import the workflows used for assembly
 include assembly_wf from './modules/assembly' params(
     output_folder: output_folder,
+    output_prefix: params.output_prefix,
     phred_offset: params.phred_offset,
     min_identity: params.min_identity,
     min_coverage: params.min_coverage,
@@ -385,33 +383,35 @@ workflow {
         alignment_wf.out.cag_csv,
         alignment_wf.out.gene_abund_feather,
         alignment_wf.out.cag_abund_feather,
-        alignment_wf.out.famli_json_list,
         countReadsSummary.out,
         manifest_file,
         alignment_wf.out.specimen_gene_count_csv,
-        collectBreakaway.out
+        alignment_wf.out.gene_length_csv,
+        collectBreakaway.out,
     )
 
     // If we performed de novo assembly, add the gene assembly information
     if ( params.gene_fasta ) {
-        finalHDF = collectAbundances.out
+        resultsHDF = collectAbundances.out
+        detailedHDF = alignment_wf.out.detailed_hdf
     } else {
         addGeneAssembly(
             collectAbundances.out,
-            assembly_wf.out.allele_gene_tsv,
-            assembly_wf.out.allele_assembly_csv
+            alignment_wf.out.detailed_hdf,
+            assembly_wf.out.allele_assembly_csv_list
         )
-        finalHDF = addGeneAssembly.out
+        resultsHDF = addGeneAssembly.out[0]
+        detailedHDF = addGeneAssembly.out[1]
     }
 
     // If we performed statistical analysis, add the results to the HDF5
     if ( params.formula ) {
         addCorncobResults(
-            finalHDF,
+            resultsHDF,
             corncob_wf.out
         )
 
-        finalHDF = addCorncobResults.out
+        resultsHDF = addCorncobResults.out
     }
 
     // If we performed functional analysis with eggNOG, add the results to the HDF5
@@ -419,11 +419,11 @@ workflow {
         if ( params.eggnog_db && params.eggnog_dmnd ) {
             if ( !file(params.eggnog_db).isEmpty() && !file(params.eggnog_dmnd).isEmpty() ){
                 addEggnogResults(
-                    finalHDF,
+                    resultsHDF,
                     annotation_wf.out.eggnog_tsv
                 )
 
-                finalHDF = addEggnogResults.out
+                resultsHDF = addEggnogResults.out
             }
         }
     }
@@ -437,34 +437,29 @@ workflow {
                 )
 
                 addTaxResults(
-                    finalHDF,
+                    resultsHDF,
                     annotation_wf.out.tax_tsv,
                     readTaxonomy.out
                 )
 
-                finalHDF = addTaxResults.out
+                resultsHDF = addTaxResults.out
             }
         }
     }
 
     // "Repack" the HDF5, which enhances space efficiency and adds GZIP compression
     repackFullHDF(
-        finalHDF
+        resultsHDF
     )
 
-    // Make a smaller summary HDF5 with a subset of the total data
-    makeSummaryHDF(
-        repackFullHDF.out
-    )
-
-    // "Repack" and compress that summary HDF5 as well
-    repackSummaryHDF(
-        makeSummaryHDF.out
+    // "Repack" and compress the detailed results HDF5 as well
+    repackDetailedHDF(
+        detailedHDF
     )
 
     publish:
         corncob_results to: "${output_folder}/stats/", enabled: params.formula, mode: "copy"
         repackFullHDF.out to: "${output_folder}", mode: "copy", overwrite: true
-        repackSummaryHDF.out to: "${output_folder}", mode: "copy", overwrite: true
+        repackDetailedHDF.out to: "${output_folder}", mode: "copy", overwrite: true
 
 }

--- a/modules/alignment.nf
+++ b/modules/alignment.nf
@@ -48,6 +48,7 @@ workflow alignment_wf {
     take:
         gene_fasta
         reads_ch
+        output_prefix
 
     main:
 
@@ -70,7 +71,8 @@ workflow alignment_wf {
     // Make a single table with the abundance of every gene across every sample
     assembleAbundances(
         famli.out.toSortedList(),
-        params.cag_batchsize
+        params.cag_batchsize,
+        output_prefix
     )
 
     // Group shards of genes into Co-Abundant Gene Groups (CAGs)
@@ -232,12 +234,13 @@ process assembleAbundances {
     input:
     file sample_jsons
     val cag_batchsize
+    val output_prefix
 
     output:
     file "gene.abund.feather"
     file "gene_list.*.csv.gz"
     file "specimen_gene_count.csv.gz"
-    file "${params.output_prefix}.details.hdf5"
+    file "${output_prefix}.details.hdf5"
     path "gene_length.csv.gz"
 
 
@@ -280,7 +283,7 @@ all_abund = dict()
 all_gene_names = set([])
 
 # All abundance tables will be written out to HDF5
-store = pd.HDFStore("${params.output_prefix}.details.hdf5", "w")
+store = pd.HDFStore("${output_prefix}.details.hdf5", "w")
 
 # Keep track of the length of each gene
 gene_length_dict = dict()

--- a/modules/assembly.nf
+++ b/modules/assembly.nf
@@ -427,7 +427,15 @@ gene_alignments = pd.read_csv(
 
 # Add the gene name to the gene annotation table
 assembly_df["catalog_gene"] = assembly_df["gene_name"].apply(
-    gene_alignments.set_index("allele")["gene"].get
+    gene_alignments.groupby(
+        "allele"
+    ).head(
+        1
+    ).set_index(
+        "allele"
+    )[
+        "gene"
+    ].get
 )
 print("%d / %d genes have an annotation in the gene catalog" % (assembly_df["catalog_gene"].dropna().shape[0], assembly_df.shape[0]))
 

--- a/modules/assembly.nf
+++ b/modules/assembly.nf
@@ -392,6 +392,8 @@ process annotateAssemblies {
     container "${container__pandas}"
     label 'mem_medium'
     errorStrategy 'retry'
+
+    publishDir "${params.output_folder}/assembly/${specimen}", mode: "copy"
     
     input:
     tuple val(specimen), file(assembly_csv), file(alignment_tsv)

--- a/modules/assembly.nf
+++ b/modules/assembly.nf
@@ -1,5 +1,8 @@
 // Processes to perform de novo assembly and annotate those assembled sequences
 
+// Default parameters
+params.output_prefix = "geneshot"
+
 // Containers
 container__assembler = "quay.io/biocontainers/megahit:1.2.9--h8b12597_0"
 container__pandas = "quay.io/fhcrc-microbiome/python-pandas@sha256:b57953e513f1f797522f88fa6afca187cdd190ca90181fa91846caa66bdeb5ed"


### PR DESCRIPTION
Instead of having one HDF5 with everything and one HDF5 with a subset, this refactor splits everything into `${params.output_prefix}.results.hdf5` and `${params.output_prefix}.details.hdf5`

The `details.hdf5` contains the objects which I think will be particularly large: `/abund/gene/long/<>` and `/abund/allele/assembly/<>`. The main object, `results.hdf5` contains everything else.