### PR TITLE
Automatically validate output file format

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -48,6 +48,9 @@ jobs:
       - name:  Run geneshot
         run: |
           NXF_VER=20.01.0 nextflow run main.nf -c nextflow.config -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --formula "label1 + label2" --distance_threshold 0.5 -w work/ --noannot -with-docker ubuntu:latest --nopreprocess
+      - name:  Validate results
+        run: |
+          docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas@sha256:b57953e513f1f797522f88fa6afca187cdd190ca90181fa91846caa66bdeb5ed python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5
 
   no_formula:
     runs-on: ubuntu-latest
@@ -69,6 +72,9 @@ jobs:
       - name:  Run geneshot
         run: |
           NXF_VER=20.01.0 nextflow run main.nf -c nextflow.config -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --distance_threshold 0.5 -w work/ --noannot -with-docker ubuntu:latest
+      - name:  Validate results
+        run: |
+          docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas@sha256:b57953e513f1f797522f88fa6afca187cdd190ca90181fa91846caa66bdeb5ed python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5
   
   no_assembly:
     runs-on: ubuntu-latest
@@ -90,6 +96,9 @@ jobs:
       - name:  Run geneshot
         run: |
           NXF_VER=20.01.0 nextflow run main.nf -c nextflow.config -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --formula "label1 + label2" --distance_threshold 0.5 -w work/ --noannot -with-docker ubuntu:latest --gene_fasta data/genes.fasta.2.gz
+      - name:  Validate results
+        run: |
+          docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas@sha256:b57953e513f1f797522f88fa6afca187cdd190ca90181fa91846caa66bdeb5ed python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5
 
   eggnog:
     runs-on: ubuntu-latest
@@ -111,3 +120,6 @@ jobs:
       - name:  Run geneshot
         run: |
           NXF_VER=20.01.0 nextflow run main.nf -c nextflow.config -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --formula "label1 + label2" --distance_threshold 0.5 -w work/ -with-docker ubuntu:latest --gene_fasta data/genes.fasta.2.gz --eggnog_dmnd https://github.com/eggnogdb/eggnog-mapper/raw/master/test/test_db.dmnd --eggnog_db https://github.com/eggnogdb/eggnog-mapper/raw/master/test/test_eggnog.db --taxonomic_dmnd false
+      - name:  Validate results
+        run: |
+          docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas@sha256:b57953e513f1f797522f88fa6afca187cdd190ca90181fa91846caa66bdeb5ed python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -98,7 +98,7 @@ jobs:
           NXF_VER=20.01.0 nextflow run main.nf -c nextflow.config -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --formula "label1 + label2" --distance_threshold 0.5 -w work/ --noannot -with-docker ubuntu:latest --gene_fasta data/genes.fasta.2.gz
       - name:  Validate results
         run: |
-          docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas@sha256:b57953e513f1f797522f88fa6afca187cdd190ca90181fa91846caa66bdeb5ed python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5
+          docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas@sha256:b57953e513f1f797522f88fa6afca187cdd190ca90181fa91846caa66bdeb5ed python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5 --skip-assembly
 
   eggnog:
     runs-on: ubuntu-latest
@@ -122,4 +122,4 @@ jobs:
           NXF_VER=20.01.0 nextflow run main.nf -c nextflow.config -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --formula "label1 + label2" --distance_threshold 0.5 -w work/ -with-docker ubuntu:latest --gene_fasta data/genes.fasta.2.gz --eggnog_dmnd https://github.com/eggnogdb/eggnog-mapper/raw/master/test/test_db.dmnd --eggnog_db https://github.com/eggnogdb/eggnog-mapper/raw/master/test/test_eggnog.db --taxonomic_dmnd false
       - name:  Validate results
         run: |
-          docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas@sha256:b57953e513f1f797522f88fa6afca187cdd190ca90181fa91846caa66bdeb5ed python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5
+          docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas@sha256:b57953e513f1f797522f88fa6afca187cdd190ca90181fa91846caa66bdeb5ed python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5 --skip-assembly

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,6 +24,9 @@ jobs:
       - name:  Run geneshot
         run: |
           NXF_VER=20.01.0 nextflow run main.nf -c nextflow.config -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --formula "label1 + label2" --distance_threshold 0.5 -w work/ --eggnog_db false --eggnog_dmnd false --taxonomic_dmnd false -with-docker ubuntu:latest
+      - name:  Validate results
+        run: |
+          docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas@sha256:b57953e513f1f797522f88fa6afca187cdd190ca90181fa91846caa66bdeb5ed python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5
 
   no_preprocessing:
     runs-on: ubuntu-latest

--- a/bin/validate_geneshot_output.py
+++ b/bin/validate_geneshot_output.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+
+import argparse
+import logging
+import os
+import pandas as pd
+
+# Set up logging
+logFormatter = logging.Formatter(
+    '%(asctime)s %(levelname)-8s [validate_geneshot_output.py] %(message)s'
+)
+rootLogger = logging.getLogger()
+rootLogger.setLevel(logging.INFO)
+
+# Write to STDOUT
+consoleHandler = logging.StreamHandler()
+consoleHandler.setFormatter(logFormatter)
+rootLogger.addHandler(consoleHandler)
+
+def validate_results_hdf(results_hdf):
+    """Validate that the results HDF has all expected data."""
+
+    for key_name in [
+        "/manifest",
+        "/summary/all",
+        "/annot/gene/cag",
+        "/annot/gene/all",
+        "/annot/cag/all",
+        "/abund/gene/wide",
+        "/abund/cag/wide",
+        "/ordination/pca",
+        "/ordination/tsne"
+    ]:
+        # Try to read the table
+        df = read_table_from_hdf(results_hdf, key_name)
+
+        # Report errors with empty rows
+        assert df.shape[0] > 0, "{} in {} has 0 rows".format(key_name, results_hdf)
+
+    # Some tables should be indexed -- let's check for that
+    for key_name, where_str in [
+        ("/abund/cag/wide", "CAG == 0"),
+        ("/abund/cag/wide", "CAG == 1"),
+        ("/annot/gene/all", "CAG == 0"),
+        ("/annot/gene/all", "CAG == 1"),
+    ]:
+        df = read_table_from_hdf(results_hdf, key_name, where = where_str)
+        msg = "Could not read index ({}) in {}".format(key_name, where_str)
+        assert df.shape[0] > 0, msg
+
+
+def validate_details_hdf(details_hdf, manifest_df):
+    """Validate that the details HDF has all expected data."""
+
+    # Iterate over every sample from the manifest
+    for sample_name in manifest_df["specimen"].values:
+        # Iterate over every table which should be present
+        for key_name in [
+            "/abund/allele/assembly/",
+            "/abund/gene/long/",
+        ]:
+            # Try to read the table
+            df = read_table_from_hdf(details_hdf, key_name + sample_name)
+
+            # Report errors with empty rows
+            msg = "{} in {} has 0 rows".format(key_name + sample_name, details_hdf)
+            assert df.shape[0] > 0, msg
+
+
+def read_table_from_hdf(hdf_fp, key_name, **kwargs):
+    logging.info("Attempting to read {} from {} {}".format(
+        key_name,
+        hdf_fp,
+        "({})".format(", ".join(["{}={}".format(k, v) for k, v in kwargs.items()])) if len(kwargs) > 0 else ""
+    ))
+    with pd.HDFStore(hdf_fp, "r") as store:
+        assert key_name in store, "{} not found in {}".format(key_name, hdf_fp)
+        return pd.read_hdf(store, key_name, **kwargs)
+
+
+def validate_geneshot_output(results_hdf, details_hdf):
+    """Validate that the geneshot outputs have all expected data."""
+    assert os.path.exists(results_hdf)
+    assert os.path.exists(details_hdf)
+
+
+    # Validate the results HDF
+    validate_results_hdf(results_hdf)
+
+    # Read the manifest from the results HDF
+    manifest_df = read_table_from_hdf(results_hdf, "/manifest")
+
+    # Validate the details HDF
+    validate_details_hdf(details_hdf, manifest_df)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--results-hdf", 
+        help = "Geneshot results output file (*.results.hdf5)",
+        required = True
+    )
+    parser.add_argument(
+        "--details-hdf", 
+        help = "Geneshot details output file (*.details.hdf5)",
+        required = True
+    )
+
+    args = parser.parse_args()
+
+    validate_geneshot_output(
+        args.results_hdf,
+        args.details_hdf
+    )

--- a/modules/general.nf
+++ b/modules/general.nf
@@ -380,7 +380,13 @@ with pd.HDFStore("${params.output_prefix}.results.hdf5", "w") as store:
 
 
     # Write to HDF5
-    cag_abund_df.to_hdf(store, "/abund/cag/wide")
+    cag_abund_df.to_hdf(
+        store, 
+        "/abund/cag/wide",
+        format = "table",
+        data_columns = ["CAG"],
+        complevel = 5
+    )
 
     # Perform ordination, both PCA and t-SNE and write to store
     for ordination_type in ["pca", "tsne"]:
@@ -437,7 +443,12 @@ with pd.HDFStore("${params.output_prefix}.results.hdf5", "w") as store:
 
     # Now create the `/annot/gene/all` table, which will be added to later
     # with the taxonomic and functional annotations, if those are performed
-    cag_df.to_hdf(store, "/annot/gene/all")
+    cag_df.to_hdf(
+        store, 
+        "/annot/gene/all",
+        format = "table",
+        data_columns = True
+    )
 
     # Make a summary table describing each CAG with size, mean_abundance, and prevalence
     # Save it in the HDF5 as "/annot/cag/all"
@@ -700,7 +711,9 @@ with pd.HDFStore("${results_hdf}", "a") as store:
     # Write summary annotation table to HDF5
     gene_annot.to_hdf(
         store, 
-        "/annot/gene/all"
+        "/annot/gene/all",
+        format = "table",
+        data_columns = ["gene", "CAG"]
     )
 
 """


### PR DESCRIPTION
This just applies to the HDF5 files that are created, checking for the existence of a set of tables and also making sure that some tables have the proper index columns defined.

As it stands:

`results.hdf5`:

- `/manifest`
- `/summary/all`
- `/annot/gene/cag`
- `/annot/gene/all`
- `/annot/cag/all`
- `/abund/gene/wide` (index on `CAG`)
- `/abund/cag/wide` (index on `CAG`)
- `/ordination/pca`
- `/ordination/tsne`

`details.hdf5`:

- `/abund/allele/assembly/<specimen>`
- `/abund/gene/long/<specimen>`