### PR TITLE
Bugfixes and enhancements

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,7 +50,7 @@ jobs:
           NXF_VER=20.01.0 nextflow run main.nf -c nextflow.config -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --formula "label1 + label2" --distance_threshold 0.5 -w work/ --noannot -with-docker ubuntu:latest --nopreprocess
       - name:  Validate results
         run: |
-          docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas@sha256:b57953e513f1f797522f88fa6afca187cdd190ca90181fa91846caa66bdeb5ed python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5
+          docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas@sha256:v1.0.3 python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5
 
   no_formula:
     runs-on: ubuntu-latest
@@ -74,7 +74,7 @@ jobs:
           NXF_VER=20.01.0 nextflow run main.nf -c nextflow.config -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --distance_threshold 0.5 -w work/ --noannot -with-docker ubuntu:latest
       - name:  Validate results
         run: |
-          docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas@sha256:b57953e513f1f797522f88fa6afca187cdd190ca90181fa91846caa66bdeb5ed python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5
+          docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas@sha256:v1.0.3 python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5
   
   no_assembly:
     runs-on: ubuntu-latest
@@ -98,7 +98,7 @@ jobs:
           NXF_VER=20.01.0 nextflow run main.nf -c nextflow.config -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --formula "label1 + label2" --distance_threshold 0.5 -w work/ --noannot -with-docker ubuntu:latest --gene_fasta data/genes.fasta.2.gz
       - name:  Validate results
         run: |
-          docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas@sha256:b57953e513f1f797522f88fa6afca187cdd190ca90181fa91846caa66bdeb5ed python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5 --skip-assembly
+          docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas@sha256:v1.0.3 python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5 --skip-assembly
 
   eggnog:
     runs-on: ubuntu-latest
@@ -122,4 +122,4 @@ jobs:
           NXF_VER=20.01.0 nextflow run main.nf -c nextflow.config -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --formula "label1 + label2" --distance_threshold 0.5 -w work/ -with-docker ubuntu:latest --gene_fasta data/genes.fasta.2.gz --eggnog_dmnd https://github.com/eggnogdb/eggnog-mapper/raw/master/test/test_db.dmnd --eggnog_db https://github.com/eggnogdb/eggnog-mapper/raw/master/test/test_eggnog.db --taxonomic_dmnd false
       - name:  Validate results
         run: |
-          docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas@sha256:b57953e513f1f797522f88fa6afca187cdd190ca90181fa91846caa66bdeb5ed python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5 --skip-assembly
+          docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas@sha256:v1.0.3 python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5 --skip-assembly

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -143,7 +143,7 @@ jobs:
           df -h
       - name:  Run geneshot
         run: |
-          NXF_VER=20.01.0 nextflow run main.nf -c nextflow.config -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --distance_threshold 0.5 -w work/ -with-docker ubuntu:latest --gene_fasta data/genes.fasta.2.gz --composition --taxonomic_dmnd false
+          NXF_VER=20.01.0 nextflow run main.nf -c nextflow.config -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --distance_threshold 0.5 -w work/ -with-docker ubuntu:latest --gene_fasta data/genes.fasta.2.gz --composition --taxonomic_dmnd false --eggnog_db false --eggnog_dmnd false
       - name:  Validate results
         run: |
           docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas:v1.0.3 python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5 --skip-assembly

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,7 +26,7 @@ jobs:
           NXF_VER=20.01.0 nextflow run main.nf -c nextflow.config -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --formula "label1 + label2" --distance_threshold 0.5 -w work/ --eggnog_db false --eggnog_dmnd false --taxonomic_dmnd false -with-docker ubuntu:latest
       - name:  Validate results
         run: |
-          docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas@sha256:b57953e513f1f797522f88fa6afca187cdd190ca90181fa91846caa66bdeb5ed python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5
+          docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas:v1.0.3 python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5
 
   no_preprocessing:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -123,3 +123,27 @@ jobs:
       - name:  Validate results
         run: |
           docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas:v1.0.3 python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5 --skip-assembly
+
+  composition:
+    runs-on: ubuntu-latest
+    env:
+      NXF_ANSI_LOG: 0
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install Nextflow
+        run: |
+          wget -qO- get.nextflow.io | bash
+          sudo mv nextflow /usr/local/bin/
+      - name: Free disk space
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          docker rmi $(docker image ls -aq)
+          df -h
+      - name:  Run geneshot
+        run: |
+          NXF_VER=20.01.0 nextflow run main.nf -c nextflow.config -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --distance_threshold 0.5 -w work/ -with-docker ubuntu:latest --gene_fasta data/genes.fasta.2.gz --composition --taxonomic_dmnd false
+      - name:  Validate results
+        run: |
+          docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas:v1.0.3 python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5 --skip-assembly

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,7 +50,7 @@ jobs:
           NXF_VER=20.01.0 nextflow run main.nf -c nextflow.config -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --formula "label1 + label2" --distance_threshold 0.5 -w work/ --noannot -with-docker ubuntu:latest --nopreprocess
       - name:  Validate results
         run: |
-          docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas@sha256:v1.0.3 python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5
+          docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas:v1.0.3 python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5
 
   no_formula:
     runs-on: ubuntu-latest
@@ -74,7 +74,7 @@ jobs:
           NXF_VER=20.01.0 nextflow run main.nf -c nextflow.config -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --distance_threshold 0.5 -w work/ --noannot -with-docker ubuntu:latest
       - name:  Validate results
         run: |
-          docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas@sha256:v1.0.3 python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5
+          docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas:v1.0.3 python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5
   
   no_assembly:
     runs-on: ubuntu-latest
@@ -98,7 +98,7 @@ jobs:
           NXF_VER=20.01.0 nextflow run main.nf -c nextflow.config -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --formula "label1 + label2" --distance_threshold 0.5 -w work/ --noannot -with-docker ubuntu:latest --gene_fasta data/genes.fasta.2.gz
       - name:  Validate results
         run: |
-          docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas@sha256:v1.0.3 python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5 --skip-assembly
+          docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas:v1.0.3 python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5 --skip-assembly
 
   eggnog:
     runs-on: ubuntu-latest
@@ -122,4 +122,4 @@ jobs:
           NXF_VER=20.01.0 nextflow run main.nf -c nextflow.config -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --formula "label1 + label2" --distance_threshold 0.5 -w work/ -with-docker ubuntu:latest --gene_fasta data/genes.fasta.2.gz --eggnog_dmnd https://github.com/eggnogdb/eggnog-mapper/raw/master/test/test_db.dmnd --eggnog_db https://github.com/eggnogdb/eggnog-mapper/raw/master/test/test_eggnog.db --taxonomic_dmnd false
       - name:  Validate results
         run: |
-          docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas@sha256:v1.0.3 python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5 --skip-assembly
+          docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas:v1.0.3 python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5 --skip-assembly

--- a/main.nf
+++ b/main.nf
@@ -268,6 +268,7 @@ include metaphlan2_fastq from './modules/composition' params(
     output_folder: output_folder
 )
 include join_metaphlan2 from './modules/composition'
+include addMetaPhlAn2Results from './modules/general'
 
 
 workflow {

--- a/main.nf
+++ b/main.nf
@@ -66,6 +66,7 @@ params.linkage_type = "average"
 
 // Statistical analysis options
 params.formula = false
+params.fdr_method = "fdr_bh"
 
 // Function which prints help message text
 def helpMessage() {
@@ -125,6 +126,9 @@ def helpMessage() {
       --distance_threshold  Distance threshold used to group genes by co-abundance (default: 0.25)
       --linkage_type        Linkage type used to group genes by co-abundance (default: average)
       
+    For Statistical Analysis:
+      --formula             Optional formula used to estimate associations with CAG relative abundance
+      --fdr_method          FDR method used to calculate q-values for associations (default: 'fdr_bh')
 
     Batchfile:
       The manifest is a CSV with a header indicating which samples correspond to which files.
@@ -189,7 +193,9 @@ include combineReads from './modules/general' params(
 include addGeneAssembly from './modules/general'
 include readTaxonomy from './modules/general'
 include addEggnogResults from './modules/general'
-include addCorncobResults from './modules/general'
+include addCorncobResults from './modules/general' params(
+    fdr_method: params.fdr_method
+)
 include addTaxResults from './modules/general'
 include repackHDF as repackFullHDF from './modules/general'
 include repackHDF as repackDetailedHDF from './modules/general'

--- a/main.nf
+++ b/main.nf
@@ -68,6 +68,9 @@ params.linkage_type = "average"
 params.formula = false
 params.fdr_method = "fdr_bh"
 
+// Compositional analysis options
+params.composition = false
+
 // Function which prints help message text
 def helpMessage() {
     log.info"""
@@ -129,6 +132,9 @@ def helpMessage() {
     For Statistical Analysis:
       --formula             Optional formula used to estimate associations with CAG relative abundance
       --fdr_method          FDR method used to calculate q-values for associations (default: 'fdr_bh')
+
+    For Compositional Analysis:
+      --composition         When included, metaPhlAn2 will be run on all specimens
 
     Batchfile:
       The manifest is a CSV with a header indicating which samples correspond to which files.
@@ -257,6 +263,13 @@ include collectBreakaway from './modules/statistics' params(
     output_prefix: params.output_prefix
 )
 
+// Import the workflow used for composition analysis
+include metaphlan2_fastq from './modules/composition' params(
+    output_folder: output_folder
+)
+include join_metaphlan2 from './modules/composition'
+
+
 workflow {
     main:
 
@@ -317,6 +330,23 @@ workflow {
     countReadsSummary(
         countReads.out.collect()
     )
+
+    // ##########################
+    // # COMPOSITIONAL ANALYSIS #
+    // ##########################
+    if (params.composition) {
+        metaphlan2_fastq(
+            combineReads.out.map {
+                r -> [r[0], r[1], r[2]]
+            }
+        )
+        // Make a single table with all of the metaPhlAn2 results
+        join_metaphlan2(
+            metaphlan2_fastq.out.map {
+                r -> r[1]
+            }.toSortedList()
+        )
+    }
 
     // ###################################
     // # DE NOVO ASSEMBLY AND ANNOTATION #
@@ -410,6 +440,16 @@ workflow {
         )
         resultsHDF = addGeneAssembly.out[0]
         detailedHDF = addGeneAssembly.out[1]
+    }
+
+    // If we performed compositional analysis, add the results ot the HDF5
+    if (params.composition) {
+        addMetaPhlAn2Results(
+            resultsHDF,
+            join_metaphlan2.out
+        )
+
+        resultsHDF = addMetaPhlAn2Results.out
     }
 
     // If we performed statistical analysis, add the results to the HDF5

--- a/modules/assembly.nf
+++ b/modules/assembly.nf
@@ -5,7 +5,7 @@ params.output_prefix = "geneshot"
 
 // Containers
 container__assembler = "quay.io/biocontainers/megahit:1.2.9--h8b12597_0"
-container__pandas = "quay.io/fhcrc-microbiome/python-pandas@sha256:b57953e513f1f797522f88fa6afca187cdd190ca90181fa91846caa66bdeb5ed"
+container__pandas = "quay.io/fhcrc-microbiome/python-pandas:v1.0.3"
 
 include diamondDB from "./alignment" params(
     output_folder: params.output_folder

--- a/modules/assembly.nf
+++ b/modules/assembly.nf
@@ -594,7 +594,7 @@ set -e
 
 for fp in genes.emapper.annotations.*.gz; do
 
-    cat \$fp
+    cat \$fp | sed 's/#query_name/query_name/'
     rm \$fp
 
 done > genes.emapper.annotations.gz

--- a/modules/general.nf
+++ b/modules/general.nf
@@ -627,10 +627,7 @@ corncob_wide = corncob_df.loc[
 with pd.HDFStore("${results_hdf}", "a") as store:
 
     # Write corncob results to HDF5
-    corncob_df.to_hdf(store, "/stats/cag/corncob")
-
-    # Write corncob results to HDF5 in wide format
-    corncob_wide.to_hdf(store, "/stats/cag/corncob_wide")
+    corncob_wide.to_hdf(store, "/stats/cag/corncob")
 
 """
 

--- a/modules/general.nf
+++ b/modules/general.nf
@@ -692,10 +692,12 @@ eggnog_df = pd.concat([
     pd.read_csv(
         fp, 
         header=3, 
-        sep="\\t"
-    ).rename(columns=dict([("#query_name", "query_name")]))
+        sep="\\t",
+        comment="#"
+    )
     for fp in eggnog_csv_list
 ])
+assert 'query_name' in eggnog_df.columns.values
 
 print(
     "Read in eggnog results for %d genes" % 

--- a/modules/general.nf
+++ b/modules/general.nf
@@ -3,7 +3,7 @@
 container__fastatools = "quay.io/fhcrc-microbiome/fastatools:0.7.1__bcw.0.3.2"
 container__ubuntu = "ubuntu:18.04"
 container__experiment_collection = "quay.io/fhcrc-microbiome/experiment-collection@sha256:fae756a380a3d3335241b68251942a8ed0bf1ae31a33a882a430085b492e44fe"
-container__pandas = "quay.io/fhcrc-microbiome/python-pandas@sha256:b57953e513f1f797522f88fa6afca187cdd190ca90181fa91846caa66bdeb5ed"
+container__pandas = "quay.io/fhcrc-microbiome/python-pandas:v1.0.3"
 
 // Default parameters
 params.fdr_method = "fdr_bh"

--- a/modules/general.nf
+++ b/modules/general.nf
@@ -654,6 +654,42 @@ with pd.HDFStore("${results_hdf}", "a") as store:
 
 }
 
+process addMetaPhlAn2Results{
+    tag "Add composition analysis to HDF"
+    container "${container__pandas}"
+    label 'mem_medium'
+    errorStrategy 'retry'
+
+    input:
+        path results_hdf
+        path metaphlan_csv
+
+    output:
+        path "${results_hdf}"
+
+"""
+#!/usr/bin/env python3
+
+import pandas as pd
+
+# Read in the metaphlan results
+metaphlan_df = pd.read_csv("${metaphlan_csv}")
+
+print(
+    "Read in metaphlan results for %d taxa" % 
+    metaphlan_df.shape[0]
+)
+
+# Open a connection to the HDF5
+with pd.HDFStore("${results_hdf}", "a") as store:
+
+    # Write metaphlan results to HDF5
+    metaphlan_df.to_hdf(store, "/composition/metaphlan")
+
+"""
+
+}
+
 process addEggnogResults {
     tag "Add functional predictions to HDF"
     container "${container__experiment_collection}"

--- a/modules/general.nf
+++ b/modules/general.nf
@@ -626,9 +626,11 @@ corncob_wide = corncob_df.loc[
     lambda v: v.apply(lambda s: s.replace("mu.", "")) if v.name == "parameter" else v
 )
 
+assert "p_value" in corncob_wide.columns.values, corncob_wide.head()
+
 # Add the q-value (FDR-BH)
 corncob_wide = corncob_wide.assign(
-    q_value = multipletests(corncob_wide["p_value"], 0.2, "${params.fdr_method}")[1]
+    q_value = multipletests(corncob_wide.p_value, 0.2, "${params.fdr_method}")[1]
 )
 
 # Open a connection to the HDF5

--- a/modules/general.nf
+++ b/modules/general.nf
@@ -636,12 +636,13 @@ corncob_wide = corncob_df.loc[
     lambda v: v.apply(lambda s: s.replace("mu.", "")) if v.name == "parameter" else v
 )
 
-assert "p_value" in corncob_wide.columns.values, corncob_wide.head()
+# Adding the q-value is conditional on p-values being present
+if "p_value" in corncob_wide.columns.values:
 
-# Add the q-value (FDR-BH)
-corncob_wide = corncob_wide.assign(
-    q_value = multipletests(corncob_wide.p_value, 0.2, "${params.fdr_method}")[1]
-)
+    # Add the q-value (FDR-BH)
+    corncob_wide = corncob_wide.assign(
+        q_value = multipletests(corncob_wide.p_value.fillna(1), 0.2, "${params.fdr_method}")[1]
+    )
 
 # Open a connection to the HDF5
 with pd.HDFStore("${results_hdf}", "a") as store:

--- a/modules/general.nf
+++ b/modules/general.nf
@@ -481,8 +481,18 @@ with pd.HDFStore("${params.output_prefix}.results.hdf5", "w") as store:
         "/summary/experiment"
     )
 
+    # Read in the manifest provided by the user
+    manifest_df = pd.read_csv(
+        "${manifest_csv}"
+    )
+    # Drop the columns with paths to reads
+    manifest_df = manifest_df.drop(columns=["R1", "R2", "I1", "I2"])
+
+    # Drop duplicated rows (multiple read pairs from the same set of samples)
+    manifest_df = manifest_df.drop_duplicates()
+
     # Write out the manifest provided by the user
-    pd.read_csv("${manifest_csv}").to_hdf(store, "/manifest")
+    manifest_df.to_hdf(store, "/manifest")
 
 """
 

--- a/modules/mmseqs.nf
+++ b/modules/mmseqs.nf
@@ -1,4 +1,4 @@
-container__pandas = "quay.io/fhcrc-microbiome/python-pandas@sha256:b57953e513f1f797522f88fa6afca187cdd190ca90181fa91846caa66bdeb5ed"
+container__pandas = "quay.io/fhcrc-microbiome/python-pandas:v1.0.3"
 
 process linclust {
     tag "Cluster genes with similar sequences"

--- a/modules/statistics.nf
+++ b/modules/statistics.nf
@@ -301,6 +301,11 @@ numCores = ${task.cpus}
 print("Reading in ${metadata_csv}")
 metadata <- vroom::vroom("${metadata_csv}", delim=",")
 
+print("Removing columns with read paths")
+metadata <- metadata %>% 
+    select(-R1, -R2, -I1, -I2) %>%
+    unique
+
 print("Reading in ${readcounts_csv_gz}")
 counts <- vroom::vroom("${readcounts_csv_gz}", delim=",")
 total_counts <- counts[,c("specimen", "total")]

--- a/modules/statistics.nf
+++ b/modules/statistics.nf
@@ -51,7 +51,7 @@ workflow corncob_wf {
 
 process mockData {
     tag "Simulate dataset for validation"
-    container "quay.io/fhcrc-microbiome/python-pandas:latest"
+    container "quay.io/fhcrc-microbiome/python-pandas:v1.0.3"
     label 'io_limited'
 
     input:
@@ -106,7 +106,7 @@ df.reset_index(
 
 process validateFormula {
     tag "Validate user-provided formula"
-    container "quay.io/fhcrc-microbiome/python-pandas:latest"
+    container "quay.io/fhcrc-microbiome/python-pandas:v1.0.3"
     label 'io_limited'
 
     input:
@@ -149,7 +149,7 @@ for cag_id, cag_df in df.groupby("CAG"):
 // and so it needs to have access to those integer values
 process extractCounts {
     tag "Make CAG ~ sample read-count matrix"
-    container "quay.io/fhcrc-microbiome/python-pandas:latest"
+    container "quay.io/fhcrc-microbiome/python-pandas:v1.0.3"
     label 'mem_veryhigh'
     publishDir "${params.output_folder}/abund/", mode: "copy"
     
@@ -418,7 +418,7 @@ write(
 // Collect the breakaway algorithm results for all samples
 process collectBreakaway {
     tag "Join richness tables"
-    container "quay.io/fhcrc-microbiome/python-pandas:latest"
+    container "quay.io/fhcrc-microbiome/python-pandas:v1.0.3"
     label "io_limited"
     errorStrategy "retry"
     publishDir "${params.output_folder}stats", mode: "copy", overwrite: true

--- a/nextflow.config
+++ b/nextflow.config
@@ -27,11 +27,11 @@ profiles{
             }
             withLabel: 'mem_medium' {
                 cpus = 1
-                memory = 1.GB
+                memory = 4.GB
             }
             withLabel: 'mem_veryhigh' {
                 cpus = 1
-                memory = 2.GB
+                memory = 6.GB
             }
         }
     }


### PR DESCRIPTION
- Add q-values to the corncob output table #30 
- Replace with `/stats/cag/corncob` table with the wide format which was previously duplicated in the undocumented `/stats/cag/corncob_wide` table
- Pinned pandas to v1.0.3
- Removed the R1/R2/I1/I2 columns from the manifest
- Fixed bug with `/ref/taxonomy` table
- Removed comment lines from eggNOG output
- Added metaPhlAn2 for composition analysis, enabled by the --composition flag