### PR TITLE
Perform meta-analysis of corncob results by gene annotation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -134,7 +134,7 @@ jobs:
           wget https://github.com/eggnogdb/eggnog-mapper/raw/master/tests/fixtures/eggnog_proteins.dmnd && wget https://github.com/eggnogdb/eggnog-mapper/raw/master/tests/fixtures/eggnog.db
       - name:  Run geneshot
         run: |
-          NXF_VER=20.04.1 nextflow run main.nf -c nextflow.config -profile testing --manifest data/mock.manifest.long.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --formula "label1 + label2" --distance_threshold 0.15 -w work/ -with-docker ubuntu:latest --gene_fasta data/genes.fasta.2.gz --eggnog_dmnd eggnog_proteins.dmnd --eggnog_db eggnog.db --taxonomic_dmnd false
+          NXF_VER=20.04.1 nextflow run main.nf -c nextflow.config -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --formula "label1 + label2" --distance_threshold 0.15 -w work/ -with-docker ubuntu:latest --gene_fasta data/genes.fasta.2.gz --eggnog_dmnd eggnog_proteins.dmnd --eggnog_db eggnog.db --taxonomic_dmnd false
       - name:  Validate results
         run: |
           docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas:v1.0.3 python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5 --skip-assembly

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -125,7 +125,7 @@ jobs:
           df -h
       - name:  Run geneshot
         run: |
-          wget https://github.com/eggnogdb/eggnog-mapper/raw/master/tests/fixtures/eggnog_proteins.dmnd && wget https://github.com/eggnogdb/eggnog-mapper/raw/master/tests/fixtures/eggnog.db && NXF_VER=20.04.1 nextflow run main.nf -c nextflow.config -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --formula "label1 + label2" --distance_threshold 0.15 -w work/ -with-docker ubuntu:latest --gene_fasta data/genes.fasta.2.gz --eggnog_dmnd eggnog_proteins.dmnd --eggnog_db eggnog.db --taxonomic_dmnd false
+          wget https://github.com/eggnogdb/eggnog-mapper/raw/master/tests/fixtures/eggnog_proteins.dmnd && wget https://github.com/eggnogdb/eggnog-mapper/raw/master/tests/fixtures/eggnog.db && NXF_VER=20.04.1 nextflow run main.nf -c nextflow.config -profile testing --manifest data/mock.manifest.long.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --formula "label1 + label2" --distance_threshold 0.15 -w work/ -with-docker ubuntu:latest --gene_fasta data/genes.fasta.2.gz --eggnog_dmnd eggnog_proteins.dmnd --eggnog_db eggnog.db --taxonomic_dmnd false
       - name:  Validate results
         run: |
           docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas:v1.0.3 python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5 --skip-assembly

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -125,7 +125,7 @@ jobs:
           df -h
       - name:  Run geneshot
         run: |
-          wget https://github.com/eggnogdb/eggnog-mapper/raw/master/test/test_db.dmnd && wget https://github.com/eggnogdb/eggnog-mapper/raw/master/test/test_eggnog.db && NXF_VER=20.04.1 nextflow run main.nf -c nextflow.config -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --formula "label1 + label2" --distance_threshold 0.5 -w work/ -with-docker ubuntu:latest --gene_fasta data/genes.fasta.2.gz --eggnog_dmnd test_db.dmnd --eggnog_db test_eggnog.db --taxonomic_dmnd false
+          wget https://github.com/eggnogdb/eggnog-mapper/raw/master/tests/fixtures/eggnog_proteins.dmnd && wget https://github.com/eggnogdb/eggnog-mapper/raw/master/tests/fixtures/eggnog.db && NXF_VER=20.04.1 nextflow run main.nf -c nextflow.config -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --formula "label1 + label2" --distance_threshold 0.5 -w work/ -with-docker ubuntu:latest --gene_fasta data/genes.fasta.2.gz --eggnog_dmnd eggnog_proteins.dmnd --eggnog_db eggnog.db --taxonomic_dmnd false
       - name:  Validate results
         run: |
           docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas:v1.0.3 python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5 --skip-assembly

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -125,7 +125,7 @@ jobs:
           df -h
       - name:  Run geneshot
         run: |
-          wget https://github.com/eggnogdb/eggnog-mapper/raw/master/tests/fixtures/eggnog_proteins.dmnd && wget https://github.com/eggnogdb/eggnog-mapper/raw/master/tests/fixtures/eggnog.db && NXF_VER=20.04.1 nextflow run main.nf -c nextflow.config -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --formula "label1 + label2" --distance_threshold 0.25 -w work/ -with-docker ubuntu:latest --gene_fasta data/genes.fasta.2.gz --eggnog_dmnd eggnog_proteins.dmnd --eggnog_db eggnog.db --taxonomic_dmnd false
+          wget https://github.com/eggnogdb/eggnog-mapper/raw/master/tests/fixtures/eggnog_proteins.dmnd && wget https://github.com/eggnogdb/eggnog-mapper/raw/master/tests/fixtures/eggnog.db && NXF_VER=20.04.1 nextflow run main.nf -c nextflow.config -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --formula "label1 + label2" --distance_threshold 0.15 -w work/ -with-docker ubuntu:latest --gene_fasta data/genes.fasta.2.gz --eggnog_dmnd eggnog_proteins.dmnd --eggnog_db eggnog.db --taxonomic_dmnd false
       - name:  Validate results
         run: |
           docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas:v1.0.3 python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5 --skip-assembly

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -125,7 +125,7 @@ jobs:
           df -h
       - name:  Run geneshot
         run: |
-          wget https://github.com/eggnogdb/eggnog-mapper/raw/master/tests/fixtures/eggnog_proteins.dmnd && wget https://github.com/eggnogdb/eggnog-mapper/raw/master/tests/fixtures/eggnog.db && NXF_VER=20.04.1 nextflow run main.nf -c nextflow.config -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --formula "label1 + label2" --distance_threshold 0.5 -w work/ -with-docker ubuntu:latest --gene_fasta data/genes.fasta.2.gz --eggnog_dmnd eggnog_proteins.dmnd --eggnog_db eggnog.db --taxonomic_dmnd false
+          wget https://github.com/eggnogdb/eggnog-mapper/raw/master/tests/fixtures/eggnog_proteins.dmnd && wget https://github.com/eggnogdb/eggnog-mapper/raw/master/tests/fixtures/eggnog.db && NXF_VER=20.04.1 nextflow run main.nf -c nextflow.config -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --formula "label1 + label2" --distance_threshold 0.25 -w work/ -with-docker ubuntu:latest --gene_fasta data/genes.fasta.2.gz --eggnog_dmnd eggnog_proteins.dmnd --eggnog_db eggnog.db --taxonomic_dmnd false
       - name:  Validate results
         run: |
           docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas:v1.0.3 python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5 --skip-assembly

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -75,9 +75,15 @@ jobs:
       - name:  Run geneshot
         run: |
           NXF_VER=20.04.1 nextflow run main.nf -c nextflow.config -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --distance_threshold 0.5 -w work/ --noannot -with-docker ubuntu:latest
+      - name:  Download annotations
+        run: |
+          wget https://github.com/eggnogdb/eggnog-mapper/raw/master/tests/fixtures/eggnog_proteins.dmnd && wget https://github.com/eggnogdb/eggnog-mapper/raw/master/tests/fixtures/eggnog.db
+      - name:  Add annotations
+        run: |
+          NXF_VER=20.04.1 nextflow run run_annotations.nf -c nextflow.config -profile testing --input_hdf output/geneshot.results.hdf5 --gene_fasta output/ref/genes.fasta.gz --output_folder output_with_annotations --output_hdf geneshot.results.hdf5 --eggnog_db eggnog.db --eggnog_dmnd eggnog_proteins.dmnd  -w work/ -with-docker ubuntu:latest
       - name:  Run corncob
         run: |
-          NXF_VER=20.04.1 nextflow run run_corncob.nf -c nextflow.config -profile testing --input_hdf output/geneshot.results.hdf5 --input_folder output/ --output_folder output_with_corncob --output_prefix geneshot --formula "label1,label2" -w work/ -with-docker ubuntu:latest
+          NXF_VER=20.04.1 nextflow run run_corncob.nf -c nextflow.config -profile testing --input_hdf output_with_annotations/geneshot.results.hdf5 --input_folder output/ --output_folder output_with_corncob --output_prefix geneshot --formula "label1,label2" -w work/ -with-docker ubuntu:latest
       - name:  Validate results
         run: |
           docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas:v1.0.3 python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5
@@ -123,9 +129,12 @@ jobs:
           sudo apt clean
           docker rmi $(docker image ls -aq)
           df -h
+      - name:  Download annotations
+        run: |
+          wget https://github.com/eggnogdb/eggnog-mapper/raw/master/tests/fixtures/eggnog_proteins.dmnd && wget https://github.com/eggnogdb/eggnog-mapper/raw/master/tests/fixtures/eggnog.db
       - name:  Run geneshot
         run: |
-          wget https://github.com/eggnogdb/eggnog-mapper/raw/master/tests/fixtures/eggnog_proteins.dmnd && wget https://github.com/eggnogdb/eggnog-mapper/raw/master/tests/fixtures/eggnog.db && NXF_VER=20.04.1 nextflow run main.nf -c nextflow.config -profile testing --manifest data/mock.manifest.long.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --formula "label1 + label2" --distance_threshold 0.15 -w work/ -with-docker ubuntu:latest --gene_fasta data/genes.fasta.2.gz --eggnog_dmnd eggnog_proteins.dmnd --eggnog_db eggnog.db --taxonomic_dmnd false
+          NXF_VER=20.04.1 nextflow run main.nf -c nextflow.config -profile testing --manifest data/mock.manifest.long.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --formula "label1 + label2" --distance_threshold 0.15 -w work/ -with-docker ubuntu:latest --gene_fasta data/genes.fasta.2.gz --eggnog_dmnd eggnog_proteins.dmnd --eggnog_db eggnog.db --taxonomic_dmnd false
       - name:  Validate results
         run: |
           docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas:v1.0.3 python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5 --skip-assembly

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -125,7 +125,7 @@ jobs:
           df -h
       - name:  Run geneshot
         run: |
-          NXF_VER=20.04.1 nextflow run main.nf -c nextflow.config -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --formula "label1 + label2" --distance_threshold 0.5 -w work/ -with-docker ubuntu:latest --gene_fasta data/genes.fasta.2.gz --eggnog_dmnd https://github.com/eggnogdb/eggnog-mapper/raw/master/test/test_db.dmnd --eggnog_db https://github.com/eggnogdb/eggnog-mapper/raw/master/test/test_eggnog.db --taxonomic_dmnd false
+          wget https://github.com/eggnogdb/eggnog-mapper/raw/master/test/test_db.dmnd && wget https://github.com/eggnogdb/eggnog-mapper/raw/master/test/test_eggnog.db && NXF_VER=20.04.1 nextflow run main.nf -c nextflow.config -profile testing --manifest data/mock.manifest.csv --output output --hg_index data/hg_chr_21_bwa_index.tar.gz --formula "label1 + label2" --distance_threshold 0.5 -w work/ -with-docker ubuntu:latest --gene_fasta data/genes.fasta.2.gz --eggnog_dmnd test_db.dmnd --eggnog_db test_eggnog.db --taxonomic_dmnd false
       - name:  Validate results
         run: |
           docker run --rm -v $PWD:/share quay.io/fhcrc-microbiome/python-pandas:v1.0.3 python3 /share/bin/validate_geneshot_output.py --results-hdf /share/output/geneshot.results.hdf5 --details-hdf /share/output/geneshot.details.hdf5 --skip-assembly

--- a/bin/add_corncob_results.py
+++ b/bin/add_corncob_results.py
@@ -163,10 +163,11 @@ def write_corncob_by_annot(corncob_wide, gene_annot, col_name_list, fp_out_templ
                 batch_size = 0
                 batch = []
 
-    pd.concat(batch).to_csv(
-        fp_out_template.format(ix),
-        index=None
-    )
+    if len(batch) > 0:
+        pd.concat(batch).to_csv(
+            fp_out_template.format(ix),
+            index=None
+        )
 
 
 # Read in the table of corncob results

--- a/bin/add_corncob_results.py
+++ b/bin/add_corncob_results.py
@@ -136,7 +136,7 @@ def write_corncob_by_annot(corncob_wide, gene_annot, col_name_list, fp_out):
         assert col_name in gene_annot.columns.values
 
     # Reformat and write out the entire dataset
-    pd.concat([
+    df = [
         corncob_wide.loc[
             corncob_wide["CAG"].isin(genes_with_label["CAG"].unique())
         ].assign(
@@ -146,10 +146,24 @@ def write_corncob_by_annot(corncob_wide, gene_annot, col_name_list, fp_out):
         )
         for col_name in col_name_list
         for label, genes_with_label in gene_annot.groupby(col_name)
-    ]).to_csv(
-        fp_out,
-        index=None
-    )
+    ]
+    
+    if len(df) > 0:
+        pd.concat(df).to_csv(
+            fp_out,
+            index=None
+        )
+
+    else:
+        # Write a dummy file to help with data flow
+        pd.DataFrame({
+            "estimate": [1],
+            "p_value": [1],
+            "parameter": ["dummy"]
+        }).to_csv(
+            fp_out,
+            index=None
+        )
 
 
 # Read in the table of corncob results

--- a/bin/add_corncob_results.py
+++ b/bin/add_corncob_results.py
@@ -2,12 +2,14 @@
 
 import pandas as pd
 from statsmodels.stats.multitest import multipletests
+import sys
 
 # Set the path to the HDF
-hdf_fp = "${results_hdf}"
+hdf_fp = sys.argv[1]
+corncob_csv = sys.argv[2]
+fdr_method = sys.argv[3]
 
-
-def read_corncob_results(fdr_method="${params.fdr_method}", corncob_csv= "${corncob_csv}"):
+def read_corncob_results(fdr_method=fdr_method, corncob_csv=corncob_csv):
     # Read in the corncob results
     corncob_df = pd.read_csv(corncob_csv)
 
@@ -46,7 +48,7 @@ def annotate_taxa(gene_annot, hdf_fp):
     return gene_annot
 
 
-def calc_enrichment(corncob_wide, gene_annot, rank):
+def calc_enrichment(corncob_wide, gene_annot, col_name):
     """Function to calculate the enrichment of each label with each parameter from the geneshot output."""
     return
 

--- a/bin/add_corncob_results.py
+++ b/bin/add_corncob_results.py
@@ -146,6 +146,7 @@ def calc_enrichment(corncob_wide, gene_annot, col_name):
             col_name
         )
         for parameter_name, corncob_parameter_df in corncob_wide.groupby("parameter")
+        if parameter_name != "(Intercept)"
     ])
 
     # Add the FDR corrected p-values
@@ -166,6 +167,9 @@ def calc_enrichment_parameter(parameter_name, cag_pvalues, gene_annot, col_name)
     assert col_name in gene_annot.columns.values, \
         "{} not a valid column name".format(col_name)
 
+    assert gene_annot[col_name].dropna().shape[0] > 0, \
+        "All annotations are null for {}".format(col_name)
+
     # Subset to those genes belonging to CAGs which also have a p-value of any sort
     gene_annot_parameter = gene_annot.loc[
         gene_annot["CAG"].isin(cag_pvalues.index.values)
@@ -182,6 +186,9 @@ def calc_enrichment_parameter(parameter_name, cag_pvalues, gene_annot, col_name)
 
     # Keep track of all of the results
     results = []
+
+    print("Top {} annotations:".format(col_name))
+    print(gene_annot[col_name].value_counts().head())
 
     # For each annotation, pick which CAGs have it and which don't
     for annotation_label, annotated_genes in gene_annot.groupby(col_name):

--- a/bin/add_corncob_results.py
+++ b/bin/add_corncob_results.py
@@ -190,6 +190,16 @@ if len(columns_to_use) > 0:
         columns_to_use,
         "corncob.for.betta.csv.gz"
     )
+else:
+    # Write a dummy file to help with data flow
+    pd.DataFrame({
+        "estimate": [1],
+        "p_value": [1],
+        "parameter": ["dummy"]
+    }).to_csv(
+        "corncob.for.betta.csv.gz",
+        index=None
+    )
 
 # Open a connection to the HDF5
 with pd.HDFStore(hdf_fp, "a") as store:

--- a/bin/add_corncob_results.py
+++ b/bin/add_corncob_results.py
@@ -187,6 +187,9 @@ def calc_enrichment_parameter(parameter_name, cag_pvalues, gene_annot, col_name)
     for annotation_label, annotated_genes in gene_annot.groupby(col_name):
         # If there is just a single CAG with this annotation, skip it
         if annotated_genes["CAG"].unique().shape[0] == 1:
+            print("There is only a single CAG with an annotation for {}, skipping".format(
+                annotation_label
+            ))
             continue
 
         # Consider separately the CAGs with estimated coefficients > 0 or < 0
@@ -203,7 +206,17 @@ def calc_enrichment_parameter(parameter_name, cag_pvalues, gene_annot, col_name)
                 errors="ignore"
             ).dropna()
 
-            if pvalues_with_annot.shape[0] == 0 or pvalues_lacking_annot.shape[0] == 0:
+            if pvalues_lacking_annot.shape[0] == 0:
+                print("No CAGs with {} coefficients found which lack the annotation {}, skipping".format(
+                    subset_label,
+                    annotation_label
+                ))
+                continue
+            if pvalues_with_annot.shape[0] == 0:
+                print("No CAGs with {} coefficients found which have the annotation {}, skipping".format(
+                    subset_label,
+                    annotation_label
+                ))
                 continue
 
             statistic, pvalue = stats.mannwhitneyu(

--- a/bin/add_corncob_results.py
+++ b/bin/add_corncob_results.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+import pandas as pd
+from statsmodels.stats.multitest import multipletests
+
+# Set the path to the HDF
+hdf_fp = "${results_hdf}"
+
+
+def read_corncob_results(fdr_method="${params.fdr_method}", corncob_csv= "${corncob_csv}"):
+    # Read in the corncob results
+    corncob_df = pd.read_csv(corncob_csv)
+
+    print(
+        "Read in corncob results for %d CAGs" % 
+        corncob_df["CAG"].unique().shape[0]
+    )
+
+    # Make a wide version of the table with just the mu. values
+    corncob_wide = corncob_df.loc[
+        corncob_df["parameter"].apply(
+            lambda s: s.startswith("mu.")
+        )
+    ].pivot_table(
+        index = ["CAG", "parameter"],
+        columns = "type",
+        values = "value"
+    ).reset_index(
+    ).apply(
+        lambda v: v.apply(lambda s: s.replace("mu.", "")) if v.name == "parameter" else v
+    )
+
+    # Adding the q-value is conditional on p-values being present
+    if "p_value" in corncob_wide.columns.values:
+
+        # Add the q-value (FDR-BH)
+        corncob_wide = corncob_wide.assign(
+            q_value = multipletests(corncob_wide.p_value.fillna(1), 0.2, fdr_method)[1]
+        )
+
+    return corncob_wide
+
+
+# Read in the table of corncob results
+corncob_wide = read_corncob_results()
+
+# Read in the gene annotations
+gene_annot = pd.read_hdf(hdf_fp, "/annot/gene/all")
+
+# Open a connection to the HDF5
+with pd.HDFStore(hdf_fp, "a") as store:
+
+    # Write corncob results to HDF5
+    corncob_wide.to_hdf(store, "/stats/cag/corncob")

--- a/bin/add_corncob_results.py
+++ b/bin/add_corncob_results.py
@@ -141,7 +141,7 @@ def write_corncob_by_annot(corncob_wide, gene_annot, col_name_list, fp_out_templ
     batch = []
 
     for col_name in col_name_list:
-        
+
         for label, genes_with_label in gene_annot.groupby(col_name):
             df = corncob_wide.loc[
                 corncob_wide["CAG"].isin(genes_with_label["CAG"].unique())
@@ -162,6 +162,11 @@ def write_corncob_by_annot(corncob_wide, gene_annot, col_name_list, fp_out_templ
                 ix += 1
                 batch_size = 0
                 batch = []
+
+    pd.concat(batch).to_csv(
+        fp_out_template.format(ix),
+        index=None
+    )
 
 
 # Read in the table of corncob results

--- a/bin/add_corncob_results.py
+++ b/bin/add_corncob_results.py
@@ -150,9 +150,10 @@ def calc_enrichment(corncob_wide, gene_annot, col_name):
     ])
 
     # Add the FDR corrected p-values
-    results = results.assign(
-        qvalue=multipletests(results["pvalue"], 0.2, "fdr_bh")[1]
-    )
+    if "pvalue" in results.columns.values:
+        results = results.assign(
+            qvalue=multipletests(results["pvalue"], 0.2, "fdr_bh")[1]
+        )
 
     return results
 
@@ -167,8 +168,9 @@ def calc_enrichment_parameter(parameter_name, cag_pvalues, gene_annot, col_name)
     assert col_name in gene_annot.columns.values, \
         "{} not a valid column name".format(col_name)
 
-    assert gene_annot[col_name].dropna().shape[0] > 0, \
-        "All annotations are null for {}".format(col_name)
+    if gene_annot[col_name].dropna().shape[0] == 0:
+        print("All annotations are null for {}".format(col_name))
+        return
 
     # Subset to those genes belonging to CAGs which also have a p-value of any sort
     gene_annot_parameter = gene_annot.loc[
@@ -178,7 +180,8 @@ def calc_enrichment_parameter(parameter_name, cag_pvalues, gene_annot, col_name)
         gene_annot_parameter.shape[0], gene_annot_parameter["CAG"].unique().shape[0], parameter_name
     ))
 
-    assert gene_annot_parameter.shape[0] > 0
+    if gene_annot_parameter.shape[0] == 0:
+        return
 
     # Treat the CAGs separately which have positive and negative estimated coefficients
     pos_coef_pvalues = cag_pvalues.query("estimate > 0")["p_value"]

--- a/bin/add_corncob_results.py
+++ b/bin/add_corncob_results.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
+from functools import lru_cache
 import pandas as pd
+from scipy import stats
 from statsmodels.stats.multitest import multipletests
 import sys
 
@@ -43,14 +45,187 @@ def read_corncob_results(fdr_method=fdr_method, corncob_csv=corncob_csv):
     return corncob_wide
 
 
-def annotate_taxa(gene_annot, hdf_fp):
+# Taxonomy used in this analysis
+class Taxonomy:
+    def __init__(self, hdf_fp):
+
+        # Read in the taxonomy table contained in the HDF store
+        self.taxonomy_df = pd.read_hdf(
+            hdf_fp, 
+            "/ref/taxonomy"
+        ).set_index(
+            "tax_id"
+        )
+
+        # Make sure that the parent is encoded as a string
+        #  (missing values otherwise would coerce it to a float)
+        self.taxonomy_df["parent"] = self.taxonomy_df[
+            "parent"
+        ].fillna(
+            0
+        ).apply(
+            float
+        ).apply(
+            int
+        ).apply(
+            str
+        )
+
+    def parent(self, tax_id):
+        return self.taxonomy_df["parent"].get(tax_id)
+
+    def ancestors(self, tax_id, a=[]):
+
+        a = a + [tax_id]
+
+        if self.parent(tax_id) is None:
+            return a
+        elif self.parent(tax_id) == tax_id:
+            return a
+        else:
+            return self.ancestors(
+                self.parent(tax_id),
+                a=a.copy()
+            )
+
+    def name(self, tax_id):
+        return self.taxonomy_df["name"].get(tax_id)
+
+    def rank(self, tax_id):
+        return self.taxonomy_df["rank"].get(tax_id)
+
+
+def annotate_taxa(gene_annot, hdf_fp, rank_list=["family", "genus", "species"]):
     """Function to add species, genus, etc. labels to the gene annotation."""
+
+    # Read in the taxonomy
+    tax = Taxonomy(hdf_fp)
+
+    # Add an LRU cache to the `ancestors` function
+    @lru_cache(maxsize=None)
+    def ancestors(tax_id):
+        return tax.ancestors(str(tax_id))
+
+    # Add an LRU cache to the `anc_at_rank` function
+    @lru_cache(maxsize=None)
+    def anc_at_rank(tax_id, rank="species"):
+        if tax_id == 0:
+            return
+        for t in ancestors(str(tax_id)):
+            if tax.rank(t) == rank:
+                return tax.name(t)
+
+    # Add the rank-specific taxon names
+    for rank in rank_list:
+        print("Adding {} names for genes".format(rank))
+
+        gene_annot = gene_annot.assign(
+            new_label=gene_annot["tax_id"].apply(lambda t: anc_at_rank(t, rank=rank))
+        ).rename(
+            columns={"new_label": rank}
+        )
+
+    print("Finished adding taxonomic labels")
+
     return gene_annot
 
 
 def calc_enrichment(corncob_wide, gene_annot, col_name):
     """Function to calculate the enrichment of each label with each parameter from the geneshot output."""
-    return
+
+    # Calculate the enrichment for each parameter individually
+    results = pd.concat([
+        calc_enrichment_parameter(
+            parameter_name, 
+            corncob_parameter_df.set_index(
+                "CAG"
+            ).reindex(
+                columns=["p_value", "estimate"]
+            ),
+            gene_annot, 
+            col_name
+        )
+        for parameter_name, corncob_parameter_df in corncob_wide.groupby("parameter")
+    ])
+
+    # Add the FDR corrected p-values
+    results = results.assign(
+        qvalue=multipletests(results["pvalue"], 0.2, "fdr_bh")[1]
+    )
+
+    return results
+
+
+def calc_enrichment_parameter(parameter_name, cag_pvalues, gene_annot, col_name):
+
+    print("Calculating enrichment for parameter {} by {}".format(
+        parameter_name, col_name
+    ))
+
+    # Make sure that we have access to the indicated annotations
+    assert col_name in gene_annot.columns.values, \
+        "{} not a valid column name".format(col_name)
+
+    # Subset to those genes belonging to CAGs which also have a p-value of any sort
+    gene_annot_parameter = gene_annot.loc[
+        gene_annot["CAG"].isin(cag_pvalues.index.values)
+    ]
+    print("There are {:,} genes from {:,} CAGs with p-values for {}".format(
+        gene_annot_parameter.shape[0], gene_annot_parameter["CAG"].unique().shape[0], parameter_name
+    ))
+
+    assert gene_annot_parameter.shape[0] > 0
+
+    # Treat the CAGs separately which have positive and negative estimated coefficients
+    pos_coef_pvalues = cag_pvalues.query("estimate > 0")["p_value"]
+    neg_coef_pvalues = cag_pvalues.query("estimate < 0")["p_value"]
+
+    # Keep track of all of the results
+    results = []
+
+    # For each annotation, pick which CAGs have it and which don't
+    for annotation_label, annotated_genes in gene_annot.groupby(col_name):
+        # If there is just a single CAG with this annotation, skip it
+        if annotated_genes["CAG"].unique().shape[0] == 1:
+            continue
+
+        # Consider separately the CAGs with estimated coefficients > 0 or < 0
+        for subset_label, cag_pvalues_subset in [
+            ("positive", pos_coef_pvalues),
+            ("negative", neg_coef_pvalues),
+        ]:
+
+            # Get the p-values for CAGs with and without this annotation
+            pvalues_with_annot = cag_pvalues_subset.reindex(
+                index=annotated_genes["CAG"].unique()).dropna()
+            pvalues_lacking_annot = cag_pvalues_subset.drop(
+                index=annotated_genes["CAG"].unique(),
+                errors="ignore"
+            ).dropna()
+
+            if pvalues_with_annot.shape[0] == 0 or pvalues_lacking_annot.shape[0] == 0:
+                continue
+
+            statistic, pvalue = stats.mannwhitneyu(
+                pvalues_with_annot.values,
+                pvalues_lacking_annot.values,
+                alternative="less"
+            )
+
+            results.append({
+                "label": annotation_label,
+                "category": col_name,
+                "n_with_label": pvalues_with_annot.shape[0],
+                "n_lacking_label": pvalues_lacking_annot.shape[0],
+                "statistic": statistic,
+                "pvalue": pvalue,
+                "est_coef": subset_label,
+                "parameter": parameter_name
+            })
+
+    print("Processed {:,} {} labels for {}".format(len(results), col_name, parameter_name))
+
+    return pd.DataFrame(results)
 
 
 # Read in the table of corncob results

--- a/bin/add_corncob_results.py
+++ b/bin/add_corncob_results.py
@@ -200,7 +200,9 @@ if "eggNOG_desc" in gene_annot.columns.values:
 # have a given annotation
 # This will be used to run betta in a separate step
 write_corncob_by_annot(
-    corncob_wide,
+    corncob_wide.query(
+        "parameter != '(Intercept)'"
+    ),
     gene_annot,
     columns_to_use,
     "corncob.shard.{}.csv.gz"

--- a/bin/add_corncob_results.py
+++ b/bin/add_corncob_results.py
@@ -154,7 +154,7 @@ def write_corncob_by_annot(corncob_wide, gene_annot, col_name_list, fp_out_templ
             batch_size += df.shape[0]
             batch.append(df)
 
-            if batch_size >= 100:
+            if batch_size >= 10000:
                 pd.concat(batch).to_csv(
                     fp_out_template.format(ix),
                     index=None

--- a/bin/add_corncob_results.py
+++ b/bin/add_corncob_results.py
@@ -140,28 +140,28 @@ def write_corncob_by_annot(corncob_wide, gene_annot, col_name_list, fp_out_templ
     ix = 0
     batch = []
 
-    for df in [
-        corncob_wide.loc[
-            corncob_wide["CAG"].isin(genes_with_label["CAG"].unique())
-        ].assign(
-            label = label
-        ).assign(
-            annotation = col_name
-        )
-        for col_name in col_name_list
-        for label, genes_with_label in gene_annot.groupby(col_name)
-    ]:
-        batch_size += df.shape[0]
-        batch.append(df)
-
-        if batch_size >= 100:
-            pd.concat(batch).to_csv(
-                fp_out_template.format(ix),
-                index=None
+    for col_name in col_name_list:
+        
+        for label, genes_with_label in gene_annot.groupby(col_name):
+            df = corncob_wide.loc[
+                corncob_wide["CAG"].isin(genes_with_label["CAG"].unique())
+            ].assign(
+                label = label
+            ).assign(
+                annotation = col_name
             )
-            ix += 1
-            batch_size = 0
-            batch = []
+
+            batch_size += df.shape[0]
+            batch.append(df)
+
+            if batch_size >= 100:
+                pd.concat(batch).to_csv(
+                    fp_out_template.format(ix),
+                    index=None
+                )
+                ix += 1
+                batch_size = 0
+                batch = []
 
 
 # Read in the table of corncob results

--- a/bin/add_corncob_results.py
+++ b/bin/add_corncob_results.py
@@ -134,7 +134,7 @@ def calc_enrichment(corncob_wide, gene_annot, col_name):
     """Function to calculate the enrichment of each label with each parameter from the geneshot output."""
 
     # Calculate the enrichment for each parameter individually
-    results = pd.concat([
+    results = [
         calc_enrichment_parameter(
             parameter_name, 
             corncob_parameter_df.set_index(
@@ -147,15 +147,24 @@ def calc_enrichment(corncob_wide, gene_annot, col_name):
         )
         for parameter_name, corncob_parameter_df in corncob_wide.groupby("parameter")
         if parameter_name != "(Intercept)"
-    ])
+    ]
+
+    # Remove any comparisons which returned None
+    results = [r for r in results if r is not None]
+
+    if len(results) > 0:
+        results = pd.concat(results)
 
     # Add the FDR corrected p-values
-    if "pvalue" in results.columns.values:
         results = results.assign(
             qvalue=multipletests(results["pvalue"], 0.2, "fdr_bh")[1]
         )
 
-    return results
+        return results
+
+    else:
+
+        return
 
 
 def calc_enrichment_parameter(parameter_name, cag_pvalues, gene_annot, col_name):

--- a/bin/validate_geneshot_output.py
+++ b/bin/validate_geneshot_output.py
@@ -52,28 +52,6 @@ def validate_results_hdf(results_hdf):
         msg = "Could not read index ({}) in {}".format(key_name, where_str)
         assert df.shape[0] > 0, msg
 
-    # If there are corncob results AND gene annotations, there should also be enrichment tables
-    if check_for_table_in_hdf(results_hdf, "/stats/cag/corncob"):
-        logging.info("Corncob results found, checking for gene annotations")
-
-        gene_annot = read_table_from_hdf(results_hdf, "/annot/gene/all")
-
-        if "eggNOG_desc" in gene_annot.columns.values:
-            logging.info("Found eggNOG annotations -- checking for label enrichment")
-
-            df = read_table_from_hdf(results_hdf, "/stats/enrichment/eggNOG_desc")
-
-        else:
-            logging.info("No eggNOG annotation found")
-
-        if "tax_id" in gene_annot.columns.values:
-            logging.info("Found taxonomic annotations -- checking for label enrichment")
-            for rank in ["species", "genus", "family"]:
-                table_name = "/stats/enrichment/{}".format(rank)
-                df = read_table_from_hdf(results_hdf, table_name)
-        else:
-            logging.info("No taxonomic annotation found")
-
 
 def validate_details_hdf(details_hdf, manifest_df, skip_assembly=False):
     """Validate that the details HDF has all expected data."""
@@ -106,15 +84,6 @@ def read_table_from_hdf(hdf_fp, key_name, **kwargs):
     with pd.HDFStore(hdf_fp, "r") as store:
         assert key_name in store, "{} not found in {}".format(key_name, hdf_fp)
         return pd.read_hdf(store, key_name, **kwargs)
-
-
-def check_for_table_in_hdf(hdf_fp, key_name):
-    logging.info("Checking for {} in {}".format(
-        key_name,
-        hdf_fp,
-    ))
-    with pd.HDFStore(hdf_fp, "r") as store:
-        return key_name in store
 
 
 def validate_geneshot_output(results_hdf, details_hdf, skip_assembly = False):

--- a/bin/validate_geneshot_output.py
+++ b/bin/validate_geneshot_output.py
@@ -54,20 +54,25 @@ def validate_results_hdf(results_hdf):
 
     # If there are corncob results AND gene annotations, there should also be enrichment tables
     if check_for_table_in_hdf(results_hdf, "/stats/cag/corncob"):
-        print("Corncob results found, checking for gene annotations")
+        logging.info("Corncob results found, checking for gene annotations")
 
         gene_annot = read_table_from_hdf(results_hdf, "/annot/gene/all")
 
         if "eggNOG_desc" in gene_annot.columns.values:
-            print("Found eggNOG annotations -- checking for label enrichment")
+            logging.info("Found eggNOG annotations -- checking for label enrichment")
 
             df = read_table_from_hdf(results_hdf, "/stats/enrichment/eggNOG_desc")
 
+        else:
+            logging.info("No eggNOG annotation found")
+
         if "tax_id" in gene_annot.columns.values:
-            print("Found taxonomic annotations -- checking for label enrichment")
+            logging.info("Found taxonomic annotations -- checking for label enrichment")
             for rank in ["species", "genus", "family"]:
                 table_name = "/stats/enrichment/{}".format(rank)
                 df = read_table_from_hdf(results_hdf, table_name)
+        else:
+            logging.info("No taxonomic annotation found")
 
 
 def validate_details_hdf(details_hdf, manifest_df, skip_assembly=False):

--- a/data/mock.manifest.long.csv
+++ b/data/mock.manifest.long.csv
@@ -1,0 +1,11 @@
+specimen,R1,R2,I1,I2,batch,label1,label2
+Mock__1,data/Mock__1.R1.fastq.gz,data/Mock__1.R2.fastq.gz,data/Mock__1.I1.fastq.gz,data/Mock__1.I2.fastq.gz,mock,0,1
+Mock__2,data/Mock__2.R1.fastq.gz,data/Mock__2.R2.fastq.gz,data/Mock__2.I1.fastq.gz,data/Mock__2.I2.fastq.gz,mock,1,0
+Mock__3,data/Mock__3.R1.fastq.gz,data/Mock__3.R2.fastq.gz,data/Mock__3.I1.fastq.gz,data/Mock__3.I2.fastq.gz,mock,1,1
+Mock__4,data/Mock__4.R1.fastq.gz,data/Mock__4.R2.fastq.gz,data/Mock__4.I1.fastq.gz,data/Mock__4.I2.fastq.gz,mock,0,0
+Mock__11,data/Mock__11.R1.fastq.gz,data/Mock__11.R2.fastq.gz,data/Mock__11.I1.fastq.gz,data/Mock__11.I2.fastq.gz,mock,0,1
+Mock__11,data/Mock__11.R1.fastq.gz,data/Mock__11.R2.fastq.gz,data/Mock__11.I1.fastq.gz,data/Mock__11.I2.fastq.gz,mock,0,1
+Mock__12,data/Mock__12.R1.fastq.gz,data/Mock__12.R2.fastq.gz,data/Mock__12.I1.fastq.gz,data/Mock__12.I2.fastq.gz,mock,1,0
+Mock__13,data/Mock__13.R1.fastq.gz,data/Mock__13.R2.fastq.gz,data/Mock__13.I1.fastq.gz,data/Mock__13.I2.fastq.gz,mock,1,1
+Mock__14,data/Mock__14.R1.fastq.gz,data/Mock__14.R2.fastq.gz,data/Mock__14.I1.fastq.gz,data/Mock__14.I2.fastq.gz,mock,0,0
+Mock__15,data/Mock__15.R1.fastq.gz,data/Mock__15.R2.fastq.gz,data/Mock__15.I1.fastq.gz,data/Mock__15.I2.fastq.gz,mock,1,1

--- a/main.nf
+++ b/main.nf
@@ -510,7 +510,7 @@ workflow {
         )
 
         runBetta(
-            addCorncobResults.out[1]
+            addCorncobResults.out[1].flatten()
         )
 
         addBetta(

--- a/main.nf
+++ b/main.nf
@@ -467,16 +467,6 @@ workflow {
         resultsHDF = addMetaPhlAn2Results.out
     }
 
-    // If we performed statistical analysis, add the results to the HDF5
-    if ( params.formula ) {
-        addCorncobResults(
-            resultsHDF,
-            corncob_wf.out
-        )
-
-        resultsHDF = addCorncobResults.out
-    }
-
     // If we performed functional analysis with eggNOG, add the results to the HDF5
     if ( params.noannot == false ) {
         if ( params.eggnog_db && params.eggnog_dmnd ) {
@@ -508,6 +498,16 @@ workflow {
                 resultsHDF = addTaxResults.out
             }
         }
+    }
+
+    // If we performed statistical analysis, add the results to the HDF5
+    if ( params.formula ) {
+        addCorncobResults(
+            resultsHDF,
+            corncob_wf.out
+        )
+
+        resultsHDF = addCorncobResults.out
     }
 
     // "Repack" the HDF5, which enhances space efficiency and adds GZIP compression

--- a/main.nf
+++ b/main.nf
@@ -510,12 +510,12 @@ workflow {
         )
 
         runBetta(
-            addCorncobResults.out[1].flatten()
+            addCorncobResults.out[1]
         )
 
         addBetta(
-            runBetta.out.toSortedList(),
-            addCorncobResults.out[0]
+            addCorncobResults.out[0],
+            runBetta.out
         )
 
         resultsHDF = addBetta.out[0]

--- a/main.nf
+++ b/main.nf
@@ -262,7 +262,9 @@ include corncob_wf from './modules/statistics' params(
     formula: params.formula
 )
 include runBetta from './modules/statistics'
-include addBetta from './modules/statistics'
+include addBetta from './modules/statistics' params(
+    fdr_method: params.fdr_method
+)
 include breakaway from './modules/statistics'
 include collectBreakaway from './modules/statistics' params(
     output_folder: output_folder,

--- a/main.nf
+++ b/main.nf
@@ -515,7 +515,7 @@ workflow {
 
         addBetta(
             addCorncobResults.out[0],
-            runBetta.out
+            runBetta.out.collect()
         )
 
         resultsHDF = addBetta.out[0]

--- a/main.nf
+++ b/main.nf
@@ -509,21 +509,17 @@ workflow {
             corncob_wf.out
         )
 
-        if (addCorncobResults.out[1].isEmpty()) {
-            resultsHDF = addCorncobResults.out[0]
-        } else {
-            runBetta(
-                addCorncobResults.out[1]
-            )
+        runBetta(
+            addCorncobResults.out[1]
+        )
 
-            addBetta(
-                runBetta.out.toSortedList(),
-                addCorncobResults.out[0]
-            )
+        addBetta(
+            runBetta.out.toSortedList(),
+            addCorncobResults.out[0]
+        )
 
-            resultsHDF = addBetta.out[0]
+        resultsHDF = addBetta.out[0]
 
-        }
     }
 
     // "Repack" the HDF5, which enhances space efficiency and adds GZIP compression

--- a/main.nf
+++ b/main.nf
@@ -515,7 +515,7 @@ workflow {
 
         addBetta(
             addCorncobResults.out[0],
-            runBetta.out.collect()
+            runBetta.out
         )
 
         resultsHDF = addBetta.out[0]

--- a/modules/general.nf
+++ b/modules/general.nf
@@ -678,7 +678,7 @@ process addCorncobResults{
 
     output:
         path "${results_hdf}"
-        path "corncob.by.*.csv.gz" optional: true
+        path "corncob.by.*.csv.gz" optional true
 
 """
 #!/bin/bash

--- a/modules/general.nf
+++ b/modules/general.nf
@@ -678,6 +678,7 @@ process addCorncobResults{
 
     output:
         path "${results_hdf}"
+        path "corncob.by.*.csv.gz" optional: true
 
 """
 #!/bin/bash

--- a/modules/general.nf
+++ b/modules/general.nf
@@ -678,7 +678,7 @@ process addCorncobResults{
 
     output:
         path "${results_hdf}"
-        path "corncob.shard.*.csv.gz" optional true
+        path "corncob.for.betta.csv.gz" optional true
 
 """
 #!/bin/bash

--- a/modules/general.nf
+++ b/modules/general.nf
@@ -680,46 +680,9 @@ process addCorncobResults{
         path "${results_hdf}"
 
 """
-#!/usr/bin/env python3
+#!/bin/bash
 
-import pandas as pd
-from statsmodels.stats.multitest import multipletests
-
-# Read in the corncob results
-corncob_df = pd.read_csv("${corncob_csv}")
-
-print(
-    "Read in corncob results for %d CAGs" % 
-    corncob_df["CAG"].unique().shape[0]
-)
-
-# Make a wide version of the table with just the mu. values
-corncob_wide = corncob_df.loc[
-    corncob_df["parameter"].apply(
-        lambda s: s.startswith("mu.")
-    )
-].pivot_table(
-    index = ["CAG", "parameter"],
-    columns = "type",
-    values = "value"
-).reset_index(
-).apply(
-    lambda v: v.apply(lambda s: s.replace("mu.", "")) if v.name == "parameter" else v
-)
-
-# Adding the q-value is conditional on p-values being present
-if "p_value" in corncob_wide.columns.values:
-
-    # Add the q-value (FDR-BH)
-    corncob_wide = corncob_wide.assign(
-        q_value = multipletests(corncob_wide.p_value.fillna(1), 0.2, "${params.fdr_method}")[1]
-    )
-
-# Open a connection to the HDF5
-with pd.HDFStore("${results_hdf}", "a") as store:
-
-    # Write corncob results to HDF5
-    corncob_wide.to_hdf(store, "/stats/cag/corncob")
+add_corncob_results.py
 
 """
 

--- a/modules/general.nf
+++ b/modules/general.nf
@@ -682,7 +682,7 @@ process addCorncobResults{
 """
 #!/bin/bash
 
-add_corncob_results.py
+add_corncob_results.py "${results_hdf}" "${corncob_csv}" "${params.fdr_method}"
 
 """
 

--- a/modules/general.nf
+++ b/modules/general.nf
@@ -678,7 +678,7 @@ process addCorncobResults{
 
     output:
         path "${results_hdf}"
-        path "corncob.by.*.csv.gz" optional true
+        path "corncob.shard.*.csv.gz" optional true
 
 """
 #!/bin/bash

--- a/modules/general.nf
+++ b/modules/general.nf
@@ -878,7 +878,7 @@ with pd.HDFStore("${results_hdf}", "a") as store:
 process readTaxonomy {
     tag "Read the NCBI taxonomy"
     container "${container__experiment_collection}"
-    label 'io_limited'
+    label 'mem_medium'
     errorStrategy 'retry'
 
     input:

--- a/modules/general.nf
+++ b/modules/general.nf
@@ -669,7 +669,7 @@ with pd.HDFStore("${results_hdf}", "a") as store:
 process addCorncobResults{
     tag "Add statistical analysis to HDF"
     container "${container__pandas}"
-    label 'mem_medium'
+    label 'mem_veryhigh'
     errorStrategy 'retry'
 
     input:

--- a/modules/statistics.nf
+++ b/modules/statistics.nf
@@ -1,5 +1,8 @@
 // // Processes to perform statistical analysis
 
+// Container versions
+container__pandas = "quay.io/fhcrc-microbiome/python-pandas:v1.0.3"
+
 // Workflow to test out the provided formula and manifest CSV in a dry run
 // This is intended to catch the case early on where the provided formula
 // is not formatted correctly, or does not match the manifest (sample sheet)

--- a/modules/statistics.nf
+++ b/modules/statistics.nf
@@ -581,9 +581,12 @@ library(magrittr)
 library(reshape2)
 library(breakaway)
 
+# Use vroom to read in the table
+Sys.setenv("VROOM_CONNECTION_SIZE" = 131072 * 20)
+
 # Read in all of the data for a single covariate
 print("Reading in $labelled_corncob_csv")
-df <- read_csv("$labelled_corncob_csv")
+df <- vroom::vroom("$labelled_corncob_csv", delim=",")
 df <- as.tibble(df)
 
 print(head(df))

--- a/modules/statistics.nf
+++ b/modules/statistics.nf
@@ -564,7 +564,7 @@ print("Done")
 // Other columns include CAG, parameter, estimate, and std_error
 process runBetta {
     container "quay.io/fhcrc-microbiome/breakaway:latest"
-    label "mem_veryhigh"
+    label "mem_medium"
     errorStrategy "retry"
     
     input:

--- a/modules/statistics.nf
+++ b/modules/statistics.nf
@@ -626,7 +626,7 @@ fault_tolerant_betta <- function(df, f){
 }
 
 # Perform meta-analysis combining the results for each label, and each parameter
-results <- df %>% group_by(annotation) %>% group_by(label) %>% group_by(parameter) %>% fault_tolerant_betta
+results <- df %>% group_by(annotation, label, parameter) %>% group_modify(fault_tolerant_betta, .keep=TRUE)
 
 # Write out to a CSV
 write.table(results, file=gzfile("${labelled_corncob_csv}.betta.csv.gz"), sep=",", row.names=FALSE)

--- a/modules/statistics.nf
+++ b/modules/statistics.nf
@@ -661,6 +661,10 @@ df = []
 # Iterate over each input file
 for fp in "${betta_csv_list}".split(" "):
 
+    # Skip empty strings
+    if len(fp) <= 1:
+        continue
+
     # Each input file should be named corncob.by.{annotation_type}.csv.gz.betta.csv.gz
 
     # Make sure that the file has the expected prefix and suffix

--- a/modules/statistics.nf
+++ b/modules/statistics.nf
@@ -650,6 +650,7 @@ process addBetta{
 #!/usr/bin/env python3
 
 import pandas as pd
+from statsmodels.stats.multitest import multipletests
 
 # Keep track of the results for each set of labels
 df = []
@@ -688,11 +689,14 @@ if len(df) > 0:
         print("Writing to %s" % key)
 
         # Join all of the results and write as a single table
-        pd.concat(
+        df = pd.concat(
             df
         ).reset_index(
             drop=True
-        ).to_hdf(store, key)
+        )
+        
+        # Write to HDF
+        df.to_hdf(store, key)
 
         print("Closing store")
 

--- a/modules/statistics.nf
+++ b/modules/statistics.nf
@@ -626,7 +626,7 @@ fault_tolerant_betta <- function(df, f){
 }
 
 # Perform meta-analysis combining the results for each label, and each parameter
-results <- df %>% group_by(annotation, label, parameter) %>% group_modify(fault_tolerant_betta, .keep=TRUE)
+results <- df %>% group_by(annotation, label, parameter) %>% group_modify(fault_tolerant_betta)
 
 # Write out to a CSV
 write.table(results, file=gzfile("${labelled_corncob_csv}.betta.csv.gz"), sep=",", row.names=FALSE)

--- a/modules/statistics.nf
+++ b/modules/statistics.nf
@@ -671,7 +671,9 @@ import pandas as pd
 from statsmodels.stats.multitest import multipletests
 
 betta_csv = "${betta_csv}"
-if os.path.exists(betta_csv):
+if len(betta_csv) > 1:
+
+    assert os.path.exists(betta_csv)
 
     # Read in from the flat file
     df = pd.read_csv(betta_csv)

--- a/modules/statistics.nf
+++ b/modules/statistics.nf
@@ -599,7 +599,6 @@ trim_trailing <- function(v){round(v, num_decimal_places(v) - 1)}
 # Make a function to run betta while tolerating faults
 fault_tolerant_betta <- function(df, f){
     if(nrow(df) == 1){
-        print(df)
         return(
             data.frame(
                 estimate=df[1,"estimate"],
@@ -624,12 +623,11 @@ fault_tolerant_betta <- function(df, f){
                 return(NULL)
             })
         if(!is.null(r)){
-            print(r)
             return(
                 data.frame(
-                    estimate=r\$table[1,"Estimates"],
-                    std_error=r\$table[1,"Standard Errors"],
-                    p_value=r\$table[1,"p-values"],
+                    estimate=r[1,"Estimates"],
+                    std_error=r[1,"Standard Errors"],
+                    p_value=r[1,"p-values"],
                 )
             )
         } else {

--- a/modules/statistics.nf
+++ b/modules/statistics.nf
@@ -675,23 +675,28 @@ for fp in "${betta_csv_list}".split(" "):
         )
     )
 
-# Open a connection to the HDF5
-with pd.HDFStore("${results_hdf}", "a") as store:
+if len(df) > 0:
 
-    # Write to HDF5
-    key = "/stats/cag/betta/"
-    print("Writing to %s" % key)
+    # Open a connection to the HDF5
+    with pd.HDFStore("${results_hdf}", "a") as store:
 
-    # Join all of the results and write as a single table
-    pd.concat(
-        df
-    ).reset_index(
-        drop=True
-    ).to_hdf(store, key)
+        # Write to HDF5
+        key = "/stats/cag/betta/"
+        print("Writing to %s" % key)
 
-    print("Closing store")
+        # Join all of the results and write as a single table
+        pd.concat(
+            df
+        ).reset_index(
+            drop=True
+        ).to_hdf(store, key)
 
-print("Done")
+        print("Closing store")
+
+    print("Done")
+
+else:
+    print("No betta results found -- returning unopened results HDF")
 
 """
 

--- a/modules/statistics.nf
+++ b/modules/statistics.nf
@@ -598,6 +598,15 @@ trim_trailing <- function(v){round(v, num_decimal_places(v) - 1)}
 
 # Make a function to run betta while tolerating faults
 fault_tolerant_betta <- function(df, f){
+    if(nrow(df) == 1){
+        return(
+            data.frame(
+                estimate=df[1,"estimate"],
+                std_error=df[1,"std_error"],
+                p_value=df[1,"p_value"],
+            )
+        )
+    }
     chats <- df\$estimate
     ses <- df\$std_error
     r <- NULL
@@ -614,7 +623,13 @@ fault_tolerant_betta <- function(df, f){
                 return(NULL)
             })
         if(!is.null(r)){
-            return(r)
+        return(
+            data.frame(
+                estimate=r\$table[1,"Estimates"],
+                std_error=r\$table[1,"Standard Errors"],
+                p_value=r\$table[1,"p-values"],
+            )
+        )
         } else {
             print("Trimming down the input data")
             chats <- trim_trailing(chats)

--- a/modules/statistics.nf
+++ b/modules/statistics.nf
@@ -659,7 +659,7 @@ process addBetta{
 
     input:
         path results_hdf
-        path betta_csv optional true
+        path betta_csv
 
     output:
         path "${results_hdf}"

--- a/modules/statistics.nf
+++ b/modules/statistics.nf
@@ -603,7 +603,7 @@ fault_tolerant_betta <- function(df, f){
             data.frame(
                 estimate=df[1,"estimate"],
                 std_error=df[1,"std_error"],
-                p_value=df[1,"p_value"],
+                p_value=df[1,"p_value"]
             )
         )
     }
@@ -627,7 +627,7 @@ fault_tolerant_betta <- function(df, f){
                 data.frame(
                     estimate=r[1,"Estimates"],
                     std_error=r[1,"Standard Errors"],
-                    p_value=r[1,"p-values"],
+                    p_value=r[1,"p-values"]
                 )
             )
         } else {

--- a/modules/statistics.nf
+++ b/modules/statistics.nf
@@ -695,6 +695,15 @@ print("Read in {:,} lines from {}".format(
 # If there are real results (not just a dummy file), write to HDF5
 if df.shape[0] > 1:
 
+    # Add the q-values
+    df = df.assign(
+        q_value = multipletests(
+            df["p_value"],
+            0.2,
+            "${params.fdr_method}"
+        )[1]
+    )
+
     # Open a connection to the HDF5
     with pd.HDFStore("${results_hdf}", "a") as store:
 

--- a/modules/statistics.nf
+++ b/modules/statistics.nf
@@ -564,7 +564,7 @@ print("Done")
 // Other columns include CAG, parameter, estimate, and std_error
 process runBetta {
     container "quay.io/fhcrc-microbiome/breakaway:latest"
-    label "mem_medium"
+    label "mem_veryhigh"
     errorStrategy "retry"
     
     input:

--- a/modules/statistics.nf
+++ b/modules/statistics.nf
@@ -599,6 +599,7 @@ trim_trailing <- function(v){round(v, num_decimal_places(v) - 1)}
 # Make a function to run betta while tolerating faults
 fault_tolerant_betta <- function(df, f){
     if(nrow(df) == 1){
+        print(df)
         return(
             data.frame(
                 estimate=df[1,"estimate"],
@@ -623,13 +624,14 @@ fault_tolerant_betta <- function(df, f){
                 return(NULL)
             })
         if(!is.null(r)){
-        return(
-            data.frame(
-                estimate=r\$table[1,"Estimates"],
-                std_error=r\$table[1,"Standard Errors"],
-                p_value=r\$table[1,"p-values"],
+            print(r)
+            return(
+                data.frame(
+                    estimate=r\$table[1,"Estimates"],
+                    std_error=r\$table[1,"Standard Errors"],
+                    p_value=r\$table[1,"p-values"],
+                )
             )
-        )
         } else {
             print("Trimming down the input data")
             chats <- trim_trailing(chats)

--- a/modules/statistics.nf
+++ b/modules/statistics.nf
@@ -667,6 +667,7 @@ process addBetta{
 """
 #!/usr/bin/env python3
 
+import os
 import pandas as pd
 from statsmodels.stats.multitest import multipletests
 

--- a/modules/statistics.nf
+++ b/modules/statistics.nf
@@ -658,8 +658,8 @@ process addBetta{
     errorStrategy 'retry'
 
     input:
-        path betta_csv_list
         path results_hdf
+        path betta_csv optional true
 
     output:
         path "${results_hdf}"
@@ -670,42 +670,22 @@ process addBetta{
 import pandas as pd
 from statsmodels.stats.multitest import multipletests
 
-# Keep track of the results for each set of labels
-df = []
-
-# Iterate over each input file
-for fp in "${betta_csv_list}".split(" "):
-
-    # Skip empty strings
-    if len(fp) <= 1:
-        continue
+betta_csv = "${betta_csv}"
+if os.path.exists(betta_csv):
 
     # Read in from the flat file
-    df.append(
-        pd.read_csv(fp)
-    )
+    df = pd.read_csv(betta_csv)
+
     print("Read in {:,} lines from {}".format(
-        df[-1].shape[0],
-        fp
+        df.shape[0],
+        betta_csv
     ))
-
-if len(df) > 0:
-
-    # Join all of the results and write as a single table
-    df = pd.concat(
-        df
-    ).reset_index(
-        drop=True
-    )
-
-    print(df.head())
-    print(df.shape)
 
     # Open a connection to the HDF5
     with pd.HDFStore("${results_hdf}", "a") as store:
 
         # Write to HDF5
-        key = "/stats/cag/betta"
+        key = "/stats/enrichment/betta"
         print("Writing to %s" % key)
         
         # Write to HDF

--- a/run_annotations.nf
+++ b/run_annotations.nf
@@ -96,7 +96,7 @@ process renameHDF{
     label 'io_limited'
 
     input:
-        path results_hdf
+        path "INPUT.RESULTS.HDF"
         val new_file_name
 
     output:
@@ -104,7 +104,7 @@ process renameHDF{
 
 """#!/bin/bash
 
-mv ${results_hdf} ${new_file_name}
+mv INPUT.RESULTS.HDF ${new_file_name}
 """
 }
 

--- a/run_annotations.nf
+++ b/run_annotations.nf
@@ -17,7 +17,13 @@ params.gene_fasta = false
 params.output_hdf = false
 params.output_folder = false
 params.help = false
+params.min_coverage = 50
 params.min_identity = 90
+params.taxonomic_dmnd = false
+params.ncbi_taxdump = "ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz"
+params.eggnog_db = false
+params.eggnog_dmnd = false
+params.noannot = false
 
 // Function which prints help message text
 def helpMessage() {
@@ -77,9 +83,11 @@ include repackHDF from './modules/general' params(
 include annotation_wf from './modules/assembly' params(
     output_folder: params.output_folder,
     min_identity: params.min_identity,
+    min_coverage: params.min_coverage,
     eggnog_db: params.eggnog_db,
     eggnog_dmnd: params.eggnog_dmnd,
     taxonomic_dmnd: params.taxonomic_dmnd,
+    noannot: params.noannot
 )
 
 // Process to rename the input HDF file

--- a/run_annotations.nf
+++ b/run_annotations.nf
@@ -134,7 +134,7 @@ workflow {
     outputHDF = renameHDF.out
 
     // Add the eggNOG results
-    if (annotation_wf.out.eggnog_tsv != false) {
+    if (annotation_wf.out.eggnog_tsv != false && params.eggnog_db != false && params.eggnog_dmnd != false) {
         addEggnogResults(
             outputHDF,
             annotation_wf.out.eggnog_tsv
@@ -143,7 +143,7 @@ workflow {
     }
     
     // Add the taxonomic assignment results
-    if (annotation_wf.out.tax_tsv != false) {
+    if (annotation_wf.out.tax_tsv != false && params.ncbi_taxdump != false && params.taxonomic_dmnd != false) {
         readTaxonomy(
             file(params.ncbi_taxdump)
         )

--- a/run_annotations.nf
+++ b/run_annotations.nf
@@ -1,0 +1,157 @@
+#!/usr/bin/env nextflow
+
+/*
+  Geneshot: A pipeline to robustly identify which alleles (n.e.e peptide coding sequences)
+  are present in a microbial community.
+
+  This utility performs taxonomic and/or functional annotations on an existing geneshot
+  results object
+*/
+
+// Using DSL-2
+nextflow.preview.dsl=2
+
+// Parameters
+params.input_hdf = false
+params.gene_fasta = false
+params.output_hdf = false
+params.output_folder = false
+params.help = false
+params.min_identity = 90
+
+// Function which prints help message text
+def helpMessage() {
+    log.info"""
+    Add functional and/or taxonomic annotations to a geneshot output file.
+    This utility will create a new geneshot output file in which
+    the only difference is the annotation output results stored within.
+
+    Usage:
+
+    nextflow run Golob-Minot/geneshot/run_annotations.nf <ARGUMENTS>
+    
+    Options:
+      --input_hdf           Location for input HDF
+      --gene_fasta          Location for input 'genes.fasta.gz'
+      --output_folder       Location for output HDF
+      --output_hdf          Name of output HDF to be placed in the output folder
+      --taxonomic_dmnd      Database used for taxonomic annotation (default: false)
+                            (Data available at s3://fh-ctr-public-reference-data/tool_specific_data/geneshot/2020-01-15-geneshot/DB.refseq.tax.dmnd)
+      --ncbi_taxdump        Reference describing the NCBI Taxonomy
+                            (default: ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz)
+      --eggnog_dmnd         One of two databases used for functional annotation with eggNOG (default: false)
+                            (Data available at s3://fh-ctr-public-reference-data/tool_specific_data/geneshot/2020-01-15-geneshot/DB.eggnog_proteins.dmnd)
+      --eggnog_db           One of two databases used for functional annotation with eggNOG (default: false)
+                            (Data available at s3://fh-ctr-public-reference-data/tool_specific_data/geneshot/2020-01-15-geneshot/DB.eggnog.db)
+    
+    """.stripIndent()
+}
+
+// Show help message if the user specifies the --help flag at runtime
+if (params.help || params.input_hdf == false || params.gene_fasta == false || params.output_hdf == false || params.output_folder == false){
+    // Invoke the function above which prints the help message
+    helpMessage()
+    // Exit out and do not run anything else
+    exit 0
+}
+
+// Show help message if the user does not specify any annotations
+if (params.taxonomic_dmnd == false && params.eggnog_dmnd == false && params.eggnog_db == false){
+    // Invoke the function above which prints the help message
+    helpMessage()
+    // Exit out and do not run anything else
+    exit 0
+}
+
+// Import the process used to add annotation results to the output
+include readTaxonomy from './modules/general'
+include addTaxResults from './modules/general'
+
+include addEggnogResults from './modules/general'
+
+include repackHDF from './modules/general' params(
+    output_folder: params.output_folder
+)
+
+// Import the workflows used for annotation
+include annotation_wf from './modules/assembly' params(
+    output_folder: params.output_folder,
+    min_identity: params.min_identity,
+    eggnog_db: params.eggnog_db,
+    eggnog_dmnd: params.eggnog_dmnd,
+    taxonomic_dmnd: params.taxonomic_dmnd,
+)
+
+// Process to rename the input HDF file
+process renameHDF{
+    container "ubuntu:20.04"
+    label 'io_limited'
+
+    input:
+        path results_hdf
+        val new_file_name
+
+    output:
+        path "${new_file_name}"
+
+"""#!/bin/bash
+
+mv ${results_hdf} ${new_file_name}
+"""
+}
+
+
+workflow {
+
+    // Make sure we can find the input files
+    if(file(params.input_hdf).isEmpty()){
+        log.info"""Cannot find input file ${params.input_hdf}""".stripIndent()
+        exit 0
+    }
+    if(file(params.gene_fasta).isEmpty()){
+        log.info"""Cannot find input file ${params.gene_fasta}""".stripIndent()
+        exit 0
+    }
+
+    // Run the annotation steps on the gene catalog
+    annotation_wf(
+        file(params.gene_fasta)
+    )
+
+    // Rename the input HDF
+    renameHDF(
+        file(params.input_hdf),
+        params.output_hdf
+    )
+    outputHDF = renameHDF.out
+
+    // Add the eggNOG results
+    if (annotation_wf.out.eggnog_tsv != false) {
+        addEggnogResults(
+            outputHDF,
+            annotation_wf.out.eggnog_tsv
+        )
+        outputHDF = addEggnogResults.out
+    }
+    
+    // Add the taxonomic assignment results
+    if (annotation_wf.out.tax_tsv != false) {
+        readTaxonomy(
+            file(params.ncbi_taxdump)
+        )
+
+        addTaxResults(
+            outputHDF,
+            annotation_wf.out.tax_tsv,
+            readTaxonomy.out
+        )
+
+        outputHDF = addTaxResults.out
+    }
+
+    // Repack the HDF
+    repackHDF(
+        outputHDF
+    )
+
+}

--- a/run_annotations.nf
+++ b/run_annotations.nf
@@ -46,9 +46,9 @@ def helpMessage() {
       --ncbi_taxdump        Reference describing the NCBI Taxonomy
                             (default: ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz)
       --eggnog_dmnd         One of two databases used for functional annotation with eggNOG (default: false)
-                            (Data available at s3://fh-ctr-public-reference-data/tool_specific_data/geneshot/2020-01-15-geneshot/DB.eggnog_proteins.dmnd)
+                            (Data available at s3://fh-ctr-public-reference-data/tool_specific_data/geneshot/2020-06-17-eggNOG-v5.0/eggnog_proteins.dmnd)
       --eggnog_db           One of two databases used for functional annotation with eggNOG (default: false)
-                            (Data available at s3://fh-ctr-public-reference-data/tool_specific_data/geneshot/2020-01-15-geneshot/DB.eggnog.db)
+                            (Data available at s3://fh-ctr-public-reference-data/tool_specific_data/geneshot/2020-06-17-eggNOG-v5.0/eggnog.db)
     
     """.stripIndent()
 }

--- a/run_corncob.nf
+++ b/run_corncob.nf
@@ -227,7 +227,7 @@ workflow {
     )
 
     runBetta(
-        addCorncobResults.out[1]
+        addCorncobResults.out[1].flatten()
     )
 
     addBetta(

--- a/run_corncob.nf
+++ b/run_corncob.nf
@@ -75,7 +75,9 @@ include extractCounts from './modules/statistics' params(
 
 // Import the processes needed to run meta-analysis of corncob results by annotation
 include runBetta from './modules/statistics'
-include addBetta from './modules/statistics'
+include addBetta from './modules/statistics' params(
+    fdr_method: params.fdr_method
+)
 
 // Import the process used to add corncob results to the output
 include repackHDF from './modules/general' params(

--- a/run_corncob.nf
+++ b/run_corncob.nf
@@ -227,12 +227,12 @@ workflow {
     )
 
     runBetta(
-        addCorncobResults.out[1].flatten()
+        addCorncobResults.out[1]
     )
 
     addBetta(
-        runBetta.out.toSortedList(),
-        addCorncobResults.out[0]
+        addCorncobResults.out[0],
+        runBetta.out
     )
 
     // Repack the HDF

--- a/run_corncob.nf
+++ b/run_corncob.nf
@@ -232,7 +232,7 @@ workflow {
 
     addBetta(
         addCorncobResults.out[0],
-        runBetta.out.collect()
+        runBetta.out
     )
 
     // Repack the HDF

--- a/run_corncob.nf
+++ b/run_corncob.nf
@@ -244,7 +244,7 @@ workflow {
 
     // Repack the HDF
     repackHDF(
-        finalHDF
+        resultsHDF
     )
 
 }

--- a/run_corncob.nf
+++ b/run_corncob.nf
@@ -73,6 +73,10 @@ include extractCounts from './modules/statistics' params(
     output_folder: params.input_folder
 )
 
+// Import the processes needed to run meta-analysis of corncob results by annotation
+include runBetta from './modules/statistics'
+include addBetta from './modules/statistics'
+
 // Import the process used to add corncob results to the output
 include repackHDF from './modules/general' params(
     output_folder: params.output_folder
@@ -222,9 +226,25 @@ workflow {
         joinCorncob.out
     )
 
+    if (addCorncobResults.out[1].isEmpty()) {
+        resultsHDF = addCorncobResults.out[0]
+    } else {
+        runBetta(
+            addCorncobResults.out[1]
+        )
+
+        addBetta(
+            runBetta.out.toSortedList(),
+            addCorncobResults.out[0]
+        )
+
+        resultsHDF = addBetta.out[0]
+
+    }
+
     // Repack the HDF
     repackHDF(
-        addCorncobResults.out
+        finalHDF
     )
 
 }

--- a/run_corncob.nf
+++ b/run_corncob.nf
@@ -226,25 +226,18 @@ workflow {
         joinCorncob.out
     )
 
-    if (addCorncobResults.out[1].isEmpty()) {
-        resultsHDF = addCorncobResults.out[0]
-    } else {
-        runBetta(
-            addCorncobResults.out[1]
-        )
+    runBetta(
+        addCorncobResults.out[1]
+    )
 
-        addBetta(
-            runBetta.out.toSortedList(),
-            addCorncobResults.out[0]
-        )
-
-        resultsHDF = addBetta.out[0]
-
-    }
+    addBetta(
+        runBetta.out.toSortedList(),
+        addCorncobResults.out[0]
+    )
 
     // Repack the HDF
     repackHDF(
-        resultsHDF
+        addBetta.out[0]
     )
 
 }

--- a/run_corncob.nf
+++ b/run_corncob.nf
@@ -232,7 +232,7 @@ workflow {
 
     addBetta(
         addCorncobResults.out[0],
-        runBetta.out
+        runBetta.out.collect()
     )
 
     // Repack the HDF


### PR DESCRIPTION
After running corncob and annotating genes by taxon and/or eggNOG, we will now calculate the combined association of all of the CAGs which share a given annotation against each of the parameters of interest. 

The resulting table is being written to `/stats/enrichment/betta` and has the columns:
- `annotation`: `species`, `genus`, `family`, or `eggNOG_desc` are the current options
- `label`: The value in the annotation column being analyzed in this row
- `parameter`: The parameter from the corncob formula being analyzed in this row
- `estimate`: The combined estimate across all CAGs in this group
- `std_error`: The combined standard error of the estimate across all CAGs in this group  
- `p_value`: The probability that the true coefficient is zero
- `q_value`: The FDR-adjusted p-value (using the method specified by `--fdr_method`, `fdr_bh` by default)