### PR TITLE
Refactor assemble abundances

### DIFF
--- a/bin/validate_geneshot_output.py
+++ b/bin/validate_geneshot_output.py
@@ -27,7 +27,6 @@ def validate_results_hdf(results_hdf, check_corncob = False):
         "/annot/gene/cag",
         "/annot/gene/all",
         "/annot/cag/all",
-        "/abund/gene/wide",
         "/abund/cag/wide",
         "/ordination/pca",
         "/ordination/tsne",

--- a/local_tests/test.sh
+++ b/local_tests/test.sh
@@ -12,12 +12,12 @@ set -e
 # 3. Run this script
 
 # Test with preprocessing and a formula
-NXF_VER=19.10.0 nextflow run main.nf \
+NXF_VER=20.04.1 nextflow run main.nf \
     -c nextflow.config \
     -profile testing \
-    --manifest data/mock.manifest.2.csv \
+    --manifest data/mock.manifest.csv \
     --nopreprocess \
-    --output output0 \
+    --output output \
     --hg_index data/hg_chr_21_bwa_index.tar.gz \
     --formula "label1 + label2" \
     --distance_threshold 0.5 \
@@ -26,7 +26,7 @@ NXF_VER=19.10.0 nextflow run main.nf \
     -resume
 
 # # Test with preprocessing and a formula
-# NXF_VER=19.10.0 nextflow run main.nf \
+# NXF_VER=20.04.1 nextflow run main.nf \
 #     -c nextflow.config \
 #     -profile testing \
 #     --manifest data/mock.manifest.csv \
@@ -41,7 +41,7 @@ NXF_VER=19.10.0 nextflow run main.nf \
 #     -resume
 
 # # Test with preprocessing and no formula
-# NXF_VER=19.10.0 nextflow run main.nf \
+# NXF_VER=20.04.1 nextflow run main.nf \
 #     -c nextflow.config \
 #     -profile testing \
 #     --manifest data/mock.manifest.csv \
@@ -54,7 +54,7 @@ NXF_VER=19.10.0 nextflow run main.nf \
 #     -resume
 
 # # Test with formula and no preprocessing
-# NXF_VER=19.10.0 nextflow run main.nf \
+# NXF_VER=20.04.1 nextflow run main.nf \
 #     -c nextflow.config \
 #     -profile testing \
 #     --nopreprocess \
@@ -68,7 +68,7 @@ NXF_VER=19.10.0 nextflow run main.nf \
 #     -resume
 
 # # Test with no formula and no preprocessing
-# NXF_VER=19.10.0 nextflow run main.nf \
+# NXF_VER=20.04.1 nextflow run main.nf \
 #     -c nextflow.config \
 #     -profile testing \
 #     --nopreprocess \
@@ -80,7 +80,7 @@ NXF_VER=19.10.0 nextflow run main.nf \
 #     -resume
 
 # # Test with the gene catalog made in a previous round
-# NXF_VER=19.10.0 nextflow run main.nf \
+# NXF_VER=20.04.1 nextflow run main.nf \
 #     -c nextflow.config \
 #     -profile testing \
 #     --gene_fasta output1/ref/genes.fasta.gz \
@@ -94,7 +94,7 @@ NXF_VER=19.10.0 nextflow run main.nf \
 
 
 # # Test with the gene catalog made in a previous round and whole genome alignment
-# NXF_VER=19.10.0 nextflow run main.nf \
+# NXF_VER=20.04.1 nextflow run main.nf \
 #     -c nextflow.config \
 #     -profile testing \
 #     --gene_fasta output1/ref/genes.fasta.gz \
@@ -111,7 +111,7 @@ NXF_VER=19.10.0 nextflow run main.nf \
 #     -resume
 
 # # Test with de novo assembly and whole genome alignment
-# NXF_VER=19.10.0 nextflow run main.nf \
+# NXF_VER=20.04.1 nextflow run main.nf \
 #     -c nextflow.config \
 #     -profile testing \
 #     --nopreprocess \

--- a/local_tests/test.sh
+++ b/local_tests/test.sh
@@ -23,7 +23,8 @@ NXF_VER=20.04.1 nextflow run main.nf \
     --distance_threshold 0.5 \
     -w work/ \
     --noannot \
-    -resume
+    -resume \
+    -with-docker ubuntu:20.04
 
 # # Test with preprocessing and a formula
 # NXF_VER=20.04.1 nextflow run main.nf \

--- a/main.nf
+++ b/main.nf
@@ -399,10 +399,6 @@ workflow {
         combineReads.out,
         params.output_prefix
     )
-    // Publish the gene abundance feather file
-    publishGeneAbundances(
-        alignment_wf.out.gene_abund_feather
-    )
 
     // ########################
     // # STATISTICAL ANALYSIS #
@@ -439,7 +435,6 @@ workflow {
 
     collectAbundances(
         alignment_wf.out.cag_csv,
-        alignment_wf.out.gene_abund_feather,
         alignment_wf.out.cag_abund_feather,
         countReadsSummary.out,
         manifest_file,

--- a/modules/alignment.nf
+++ b/modules/alignment.nf
@@ -480,7 +480,7 @@ with pd.HDFStore(details_hdf, "r") as store:
             # Add the abundance of each gene to its linked CAG
             for gene_name, gene_prop in sample_depth.items():
                 abund_df[
-                    sample_namee
+                    sample_name
                 ][
                     cags_dict[
                         gene_name

--- a/modules/alignment.nf
+++ b/modules/alignment.nf
@@ -416,6 +416,7 @@ process calcCAGabund {
 #!/usr/bin/env python3
 
 from collections import defaultdict
+import os
 import pandas as pd
 import logging
 

--- a/modules/general.nf
+++ b/modules/general.nf
@@ -204,7 +204,6 @@ process collectAbundances{
 
     input:
         path cag_csv
-        path gene_abund_feather
         path cag_abund_feather
         path readcount_csv
         path manifest_csv
@@ -232,7 +231,6 @@ import pickle
 pickle.HIGHEST_PROTOCOL = 4
 
 cag_csv = "${cag_csv}"
-gene_abund_feather = "${gene_abund_feather}"
 cag_abund_feather = "${cag_abund_feather}"
 readcount_csv = "${readcount_csv}"
 specimen_gene_count_csv = "${specimen_gene_count_csv}"
@@ -469,21 +467,6 @@ with pd.HDFStore("${params.output_prefix}.results.hdf5", "w") as store:
             "/distances/%s" % metric
         )
 
-    # Read in the table with the gene-level abundances across all samples
-    gene_abund_df = pd.read_feather(
-        gene_abund_feather
-    )
-    print(
-        "Read in abundances for %d genes across %d samples" %
-        (gene_abund_df.shape[0], gene_abund_df.shape[1] - 1)
-    )
-    # Add some descriptive statistics
-    summary_dict["num_genes"] = gene_abund_df.shape[0]
-
-
-    # Write to HDF5
-    gene_abund_df.to_hdf(store, "/abund/gene/wide")
-
     # Read in the table describing which genes are grouped into which CAGs
     # This is being called 'cag_df', but it's really a table of CAG annotations per-gene,
     # so there is one row per gene.
@@ -494,6 +477,9 @@ with pd.HDFStore("${params.output_prefix}.results.hdf5", "w") as store:
         (cag_df.shape[0], cag_df["CAG"].unique().shape[0])
     )
 
+    # Save the total number of genes
+    summary_dict["num_genes"] = cag_df.shape[0]
+
     # Write to HDF5
     cag_df.to_hdf(
         store, 
@@ -502,15 +488,8 @@ with pd.HDFStore("${params.output_prefix}.results.hdf5", "w") as store:
         data_columns = ["gene", "CAG"]
     )
 
-    # Calculate prevalence and abundance information for each gene
-    gene_abund_df.set_index("index", inplace=True)
-    gene_abundance = gene_abund_df.mean(axis=1)
-    gene_prevalence = (gene_abund_df > 0).mean(axis=1)
-
     # Add that information on the gene abundance and prevalence to this gene summary table
     cag_df = cag_df.assign(
-        prevalence = cag_df["gene"].apply(gene_prevalence.get),
-        abundance = cag_df["gene"].apply(gene_abundance.get),
         length = cag_df["gene"].apply(gene_length_df.get)
     )
 

--- a/modules/general.nf
+++ b/modules/general.nf
@@ -424,6 +424,8 @@ with pd.HDFStore("${params.output_prefix}.results.hdf5", "w") as store:
     # Read in the table with the CAG-level abundances across all samples
     cag_abund_df = pd.read_feather(
         cag_abund_feather
+    ).rename(
+        columns={"index": "CAG"}
     )
     print(
         "Read in abundances for %d CAGs across %d samples" %

--- a/modules/make_cags.nf
+++ b/modules/make_cags.nf
@@ -260,10 +260,10 @@ n = 0
 gene_list = set()
 for fp in cag_csv_list:
     shard_cags = pd.read_csv(fp, compression="gzip", sep=",")
-    for _, gene_list in shard_cags.groupby("CAG"):
-        cags[ix] = gene_list['gene'].tolist()
-        ix += 1
+    for _, shard_df in shard_cags.groupby("CAG"):
+        cags[ix] = shard_df['gene'].tolist()
         gene_list.update(set(cags[ix]))
+        ix += 1
 
 logging.info(
     "Read in %d CAGs from %d shards covering %d genes" % (

--- a/modules/make_cags.nf
+++ b/modules/make_cags.nf
@@ -1,4 +1,4 @@
-container__find_cags = "quay.io/fhcrc-microbiome/find-cags:v0.12.1"
+container__find_cags = "quay.io/fhcrc-microbiome/find-cags:v0.12.2"
 
 // Default options
 params.distance_threshold = 0.5

--- a/modules/make_cags.nf
+++ b/modules/make_cags.nf
@@ -95,11 +95,6 @@ with pd.HDFStore(details_hdf, "r") as store:
             # Normalize to sum to 1
             sample_depth = sample_depth / sample_depth.sum()
 
-            logging.info("Making sure that the gene names match between the HDF5 and CSV")
-            n_mismatch = len(gene_list - set(sample_depth.index.values))
-            msg = "Gene names do not match between the HDF5 and CSV (n= %d / %d)" % (n_mismatch, len(gene_list))
-            assert n_mismatch == 0, msg
-
             # Subset down to the genes in this list
             genes_in_sample = list(
                 set(sample_depth.index.values) & gene_list
@@ -305,11 +300,6 @@ with pd.HDFStore(details_hdf, "r") as store:
 
             # Normalize to sum to 1
             sample_depth = sample_depth / sample_depth.sum()
-
-            logging.info("Making sure that the gene names match between the HDF5 and CSV")
-            n_mismatch = len(gene_list - set(sample_depth.index.values))
-            msg = "Gene names do not match between the HDF5 and CSV (n= %d / %d)" % (n_mismatch, len(gene_list))
-            assert n_mismatch == 0, msg
 
             # Subset down to the genes in this list
             genes_in_sample = list(


### PR DESCRIPTION
Having attempted to run the previous version of the pipeline on much larger datasets, it's clear that assembling a single table with all gene-level abundances is not computationally tractable.

The only impact of these changes on the output of the pipeline is that the `/abund/gene/wide` table is no longer present (neither is the matching feather file). In practice, the execution of the rest of the pipeline is unchanged.