### PR TITLE
Refactor CAG construction using Zarr

### DIFF
--- a/modules/alignment.nf
+++ b/modules/alignment.nf
@@ -455,7 +455,7 @@ logging.info("Done")
 // Summarize the abundance of every CAG across each sample
 process calcCAGabund {
     tag "Make CAG ~ sample abundance matrix"
-    container "quay.io/fhcrc-microbiome/experiment-collection@sha256:fae756a380a3d3335241b68251942a8ed0bf1ae31a33a882a430085b492e44fe"
+    container "quay.io/fhcrc-microbiome/experiment-collection:v0.2"
     label "mem_veryhigh"
     errorStrategy 'retry'
     publishDir "${params.output_folder}/abund/", mode: "copy"

--- a/modules/alignment.nf
+++ b/modules/alignment.nf
@@ -128,7 +128,7 @@ workflow alignment_wf {
 // Align each sample against the reference database of genes using DIAMOND
 process diamondDB {
     tag "Make a DIAMOND database"
-    container "quay.io/fhcrc-microbiome/famli@sha256:25c34c73964f06653234dd7804c3cf5d9cf520bc063723e856dae8b16ba74b0c"
+    container "quay.io/fhcrc-microbiome/famli:v1.5"
     label 'mem_veryhigh'
     errorStrategy 'retry'
     publishDir "${params.output_folder}/ref/", mode: "copy"
@@ -154,7 +154,7 @@ process diamondDB {
 // Align each sample against the reference database of genes using DIAMOND
 process diamond {
     tag "Align to the gene catalog"
-    container "quay.io/fhcrc-microbiome/famli@sha256:25c34c73964f06653234dd7804c3cf5d9cf520bc063723e856dae8b16ba74b0c"
+    container "quay.io/fhcrc-microbiome/famli:v1.5"
     label 'mem_veryhigh'
     errorStrategy 'retry'
     

--- a/modules/alignment.nf
+++ b/modules/alignment.nf
@@ -1,6 +1,6 @@
 // Processes used for alignment of reads against gene databases
 
-params.cag_batchsize = 100000
+params.cag_batchsize = 10000
 
 // Default options
 params.distance_threshold = 0.5
@@ -84,23 +84,23 @@ workflow alignment_wf {
     // Perform multiple rounds of combining shards to make ever-larger CAGs
     refineCAGs_round1(
         assembleAbundances.out[5],
-        makeInitialCAGs.out.toSortedList().flatten().collate(2)
+        makeInitialCAGs.out.toSortedList().flatten().collate(4)
     )
     refineCAGs_round2(
         assembleAbundances.out[5],
-        refineCAGs_round1.out.toSortedList().flatten().collate(2)
+        refineCAGs_round1.out.toSortedList().flatten().collate(4)
     )
     refineCAGs_round3(
         assembleAbundances.out[5],
-        refineCAGs_round2.out.toSortedList().flatten().collate(2)
+        refineCAGs_round2.out.toSortedList().flatten().collate(4)
     )
     refineCAGs_round4(
         assembleAbundances.out[5],
-        refineCAGs_round3.out.toSortedList().flatten().collate(2)
+        refineCAGs_round3.out.toSortedList().flatten().collate(4)
     )
     refineCAGs_round5(
         assembleAbundances.out[5],
-        refineCAGs_round4.out.toSortedList().flatten().collate(2)
+        refineCAGs_round4.out.toSortedList().flatten().collate(4)
     )
 
     // Combine the shards and make a new set of CAGs

--- a/modules/assembly.nf
+++ b/modules/assembly.nf
@@ -476,7 +476,7 @@ gzip genes.shard.*.fasta
 
 process diamond_tax {
     tag "Annotate genes by taxonomy"
-    container "quay.io/fhcrc-microbiome/famli@sha256:25c34c73964f06653234dd7804c3cf5d9cf520bc063723e856dae8b16ba74b0c"
+    container "quay.io/fhcrc-microbiome/famli:v1.5"
     label 'mem_veryhigh'
 
     input:
@@ -615,7 +615,7 @@ with gzip.open("genes.fasta.gz", "wt") as fo:
 // Use alignment to figure out which assembled allele was grouped into which gene
 process alignAlleles {
     tag "Match alleles to gene centroids"
-    container "quay.io/fhcrc-microbiome/famli@sha256:25c34c73964f06653234dd7804c3cf5d9cf520bc063723e856dae8b16ba74b0c"
+    container "quay.io/fhcrc-microbiome/famli:v1.5"
     label 'mem_medium'
     errorStrategy 'retry'
     

--- a/modules/general.nf
+++ b/modules/general.nf
@@ -849,7 +849,6 @@ with pd.HDFStore("${results_hdf}", "a") as store:
         store,
         "/annot/gene/eggnog",
         format = "fixed",
-        dtype=str,
     )
     
     # Write summary annotation table to HDF5

--- a/modules/general.nf
+++ b/modules/general.nf
@@ -2,7 +2,7 @@
 // Container versions
 container__fastatools = "quay.io/fhcrc-microbiome/fastatools:0.7.1__bcw.0.3.2"
 container__ubuntu = "ubuntu:18.04"
-container__experiment_collection = "quay.io/fhcrc-microbiome/experiment-collection@sha256:fae756a380a3d3335241b68251942a8ed0bf1ae31a33a882a430085b492e44fe"
+container__experiment_collection = "quay.io/fhcrc-microbiome/experiment-collection:v0.2"
 container__pandas = "quay.io/fhcrc-microbiome/python-pandas:v1.0.3"
 
 // Default parameters

--- a/modules/general.nf
+++ b/modules/general.nf
@@ -858,7 +858,6 @@ with pd.HDFStore("${results_hdf}", "a") as store:
         "/annot/gene/all",
         format = "table",
         data_columns = ["CAG"],
-        dtype=str,
     )
 
 """

--- a/modules/make_cags.nf
+++ b/modules/make_cags.nf
@@ -94,7 +94,10 @@ z = zarr.open("gene_abundance.zarr", mode="r")
 
 # Set up an array for gene abundances
 df = pd.DataFrame(
-    shape = (len(gene_list), len(sample_names)),
+    data = np.zeros(
+        (len(gene_list), len(sample_names)),
+        dtype = np.float32,
+    ),
     dtype = np.float32,
     index = gene_list,
     columns = sample_names
@@ -293,9 +296,13 @@ z = zarr.open("gene_abundance.zarr", mode="r")
 
 # Set up an array for CAG abundances
 df = pd.DataFrame(
-    shape = (len(cags), len(sample_names)),
+    data = np.zeros(
+        (len(cags), len(sample_names)),
+        dtype = np.float32,
+    ),
     dtype = np.float32,
-    columns = sample_names
+    columns = sample_names,
+    index = list(range(len(cags))),
 )
 
 # Iterate over each sample

--- a/modules/make_cags.nf
+++ b/modules/make_cags.nf
@@ -32,6 +32,7 @@ import os
 import pandas as pd
 import tarfile
 import zarr
+import shutil
 from ann_linkage_clustering.lib import make_cags_with_ann
 from ann_linkage_clustering.lib import iteratively_refine_cags
 from ann_linkage_clustering.lib import make_nmslib_index
@@ -184,6 +185,9 @@ fp_out = "CAGs.csv.gz"
 logging.info("Writing out CAGs to %s" % fp_out)
 cags_df.to_csv(fp_out, compression="gzip", index=None)
 
+logging.info("Deleting the temporary zarr")
+shutil.rmtree("gene_abundance.zarr")
+
 logging.info("Done")
     """
 }
@@ -216,6 +220,7 @@ import os
 import pandas as pd
 import tarfile
 import zarr
+import shutil
 from ann_linkage_clustering.lib import make_cags_with_ann
 from ann_linkage_clustering.lib import iteratively_refine_cags
 from ann_linkage_clustering.lib import make_nmslib_index
@@ -375,6 +380,9 @@ fp_out = "CAGs.csv.gz"
 
 logging.info("Writing out CAGs to %s" % fp_out)
 cags_df.to_csv(fp_out, compression="gzip", index=None)
+
+logging.info("Deleting the temporary zarr")
+shutil.rmtree("gene_abundance.zarr")
 
 logging.info("Done")
     """

--- a/modules/make_cags.nf
+++ b/modules/make_cags.nf
@@ -215,6 +215,7 @@ import numpy as np
 import os
 import pandas as pd
 import tarfile
+import zarr
 from ann_linkage_clustering.lib import make_cags_with_ann
 from ann_linkage_clustering.lib import iteratively_refine_cags
 from ann_linkage_clustering.lib import make_nmslib_index

--- a/modules/make_cags.nf
+++ b/modules/make_cags.nf
@@ -1,4 +1,4 @@
-container__find_cags = "quay.io/fhcrc-microbiome/find-cags:v0.12.2"
+container__find_cags = "quay.io/fhcrc-microbiome/find-cags:v0.13.0"
 
 // Default options
 params.distance_threshold = 0.5

--- a/modules/make_cags.nf
+++ b/modules/make_cags.nf
@@ -186,6 +186,7 @@ logging.info("Writing out CAGs to %s" % fp_out)
 cags_df.to_csv(fp_out, compression="gzip", index=None)
 
 logging.info("Deleting the temporary zarr")
+del z
 shutil.rmtree("gene_abundance.zarr")
 
 logging.info("Done")
@@ -382,8 +383,10 @@ logging.info("Writing out CAGs to %s" % fp_out)
 cags_df.to_csv(fp_out, compression="gzip", index=None)
 
 logging.info("Deleting the temporary zarr")
+del z
 shutil.rmtree("gene_abundance.zarr")
 
 logging.info("Done")
+os._exit(0)
     """
 }

--- a/modules/make_cags.nf
+++ b/modules/make_cags.nf
@@ -214,6 +214,7 @@ import nmslib
 import numpy as np
 import os
 import pandas as pd
+import tarfile
 from ann_linkage_clustering.lib import make_cags_with_ann
 from ann_linkage_clustering.lib import iteratively_refine_cags
 from ann_linkage_clustering.lib import make_nmslib_index

--- a/modules/make_cags.nf
+++ b/modules/make_cags.nf
@@ -13,7 +13,7 @@ process makeInitialCAGs {
     errorStrategy 'retry'
 
     input:
-    path details_hdf
+    path gene_abundances_zarr_tar
     path gene_list_csv
 
     output:
@@ -30,6 +30,8 @@ import nmslib
 import numpy as np
 import os
 import pandas as pd
+import tarfile
+import zarr
 from ann_linkage_clustering.lib import make_cags_with_ann
 from ann_linkage_clustering.lib import iteratively_refine_cags
 from ann_linkage_clustering.lib import make_nmslib_index
@@ -50,8 +52,28 @@ rootLogger.addHandler(consoleHandler)
 threads = int("${task.cpus}")
 pool = Pool(threads)
 
-# Set the file path to the HDF5 with gene abundances
-details_hdf = "${details_hdf}"
+# Extract everything from the gene_abundance.zarr.tar
+logging.info("Extracting ${gene_abundances_zarr_tar}")
+with tarfile.open("${gene_abundances_zarr_tar}") as tar:
+    tar.extractall()
+
+# Make sure that the expected contents are present
+for fp in [
+    "gene_names.json.gz",
+    "sample_names.json.gz",
+    "gene_abundance.zarr",
+]:
+    logging.info("Checking that %s is present" % fp)
+    assert os.path.exists(fp)
+
+# Read in the gene names and sample names as indexed in the zarr
+logging.info("Reading in gene_names.json.gz")
+with gzip.open("gene_names.json.gz", "rt") as handle:
+    gene_names = json.load(handle)
+
+logging.info("Reading in sample_names.json.gz")
+with gzip.open("sample_names.json.gz", "rt") as handle:
+    sample_names = json.load(handle)
 
 # Set the file path to the genes for this subset
 gene_list_csv = "${gene_list_csv}"
@@ -61,62 +83,37 @@ assert os.path.exists(details_hdf), details_hdf
 assert os.path.exists(gene_list_csv), gene_list_csv
 
 logging.info("Reading in the list of genes for this shard from %s" % (gene_list_csv))
-gene_list = set([
+gene_list = [
     line.rstrip("\\n")
     for line in gzip.open(gene_list_csv, "rt")
-])
+]
 logging.info("This shard contains %d genes" % (len(gene_list)))
 
-logging.info("Reading in gene abundances from %s" % details_hdf)
-df = {}
-# Open the HDF5 store
-with pd.HDFStore(details_hdf, "r") as store:
+# Open the zarr store
+logging.info("Reading in gene abundances from gene_abundance.zarr")
+z = zarr.open("gene_abundance.zarr", mode="r")
 
-    # Iterate over keys in the store
-    for k in store:
-
-        # Sample abundances have a certain prefix
-        if k.startswith("/abund/gene/long/"):
-
-            # Parse the sample name
-            sample_name = k.replace("/abund/gene/long/", "")
-            logging.info("Reading gene abundances for {}".format(sample_name))
-
-            # Read the depth of sequencing for each gene
-            sample_depth = pd.read_hdf(
-                store,
-                k
-            ).set_index(
-                "id"
-            )[
-                "depth"
-            ]
-
-            # Normalize to sum to 1
-            sample_depth = sample_depth / sample_depth.sum()
-
-            # Subset down to the genes in this list
-            genes_in_sample = list(
-                set(sample_depth.index.values) & gene_list
-            )
-
-            # Add genes from this list to the table
-            if len(genes_in_sample) > 0:
-                df[
-                    sample_name
-                ] = sample_depth.reindex(
-                    index = genes_in_sample
-                )
-
-# Make the DataFrame
-logging.info("Formatting DataFrame")
+# Set up an array for gene abundances
 df = pd.DataFrame(
-    df
-).fillna(
-    0
-).applymap(
-    np.float16
+    shape = (len(gene_list), len(sample_names)),
+    dtype = np.float32,
+    index = gene_list,
+    columns = sample_names
 )
+
+# Iterate over each sample
+for sample_ix, sample_name in enumerate(sample_names):
+
+    # Read in the abundances for this sample
+    logging.info("Reading in gene abundances for %s" % sample_name)
+    df[sample_name] = pd.Series(
+        z[:, sample_ix],
+        index=gene_names
+    ).reindex(
+        gene_list
+    ).apply(
+        np.float32
+    )
 
 max_dist = float("${params.distance_threshold}")
 logging.info("Maximum cosine distance: %s" % max_dist)
@@ -197,7 +194,7 @@ process refineCAGs {
     errorStrategy 'retry'
 
     input:
-    path details_hdf
+    path gene_abundances_zarr_tar
     path "shard.CAG.*.csv.gz"
 
     output:
@@ -206,6 +203,7 @@ process refineCAGs {
     """
 #!/usr/bin/env python3
 
+from collections import defaultdict
 import gzip
 import json
 import logging
@@ -234,11 +232,28 @@ rootLogger.addHandler(consoleHandler)
 threads = int("${task.cpus}")
 pool = Pool(threads)
 
-# Set the file path to the HDF5 with gene abundances
-details_hdf = "${details_hdf}"
+# Extract everything from the gene_abundance.zarr.tar
+logging.info("Extracting ${gene_abundances_zarr_tar}")
+with tarfile.open("${gene_abundances_zarr_tar}") as tar:
+    tar.extractall()
 
-# Make sure the files exist
-assert os.path.exists(details_hdf), details_hdf
+# Make sure that the expected contents are present
+for fp in [
+    "gene_names.json.gz",
+    "sample_names.json.gz",
+    "gene_abundance.zarr",
+]:
+    logging.info("Checking that %s is present" % fp)
+    assert os.path.exists(fp)
+
+# Read in the gene names and sample names as indexed in the zarr
+logging.info("Reading in gene_names.json.gz")
+with gzip.open("gene_names.json.gz", "rt") as handle:
+    gene_names = json.load(handle)
+
+logging.info("Reading in sample_names.json.gz")
+with gzip.open("sample_names.json.gz", "rt") as handle:
+    sample_names = json.load(handle)
 
 # Set the file path to the CAGs made for each subset
 cag_csv_list = [
@@ -273,63 +288,42 @@ logging.info(
     )
 )
 
-logging.info("Reading in gene abundances from %s" % details_hdf)
-df = {}
-# Open the HDF5 store
-with pd.HDFStore(details_hdf, "r") as store:
+# Open the zarr store
+logging.info("Reading in gene abundances from gene_abundance.zarr")
+z = zarr.open("gene_abundance.zarr", mode="r")
 
-    # Iterate over keys in the store
-    for k in store:
-
-        # Sample abundances have a certain prefix
-        if k.startswith("/abund/gene/long/"):
-
-            # Parse the sample name
-            sample_name = k.replace("/abund/gene/long/", "")
-            logging.info("Reading gene abundances for {}".format(sample_name))
-
-            # Read the depth of sequencing for each gene
-            sample_depth = pd.read_hdf(
-                store,
-                k
-            ).set_index(
-                "id"
-            )[
-                "depth"
-            ]
-
-            # Normalize to sum to 1
-            sample_depth = sample_depth / sample_depth.sum()
-
-            # Subset down to the genes in this list
-            genes_in_sample = list(
-                set(sample_depth.index.values) & gene_list
-            )
-
-            # Add genes from this list to the table
-            if len(genes_in_sample) > 0:
-                df[
-                    sample_name
-                ] = sample_depth.reindex(
-                    index = genes_in_sample
-                )
-
-# Make the DataFrame
-logging.info("Formatting DataFrame")
+# Set up an array for CAG abundances
 df = pd.DataFrame(
-    df
-).fillna(
-    0
-).applymap(
-    np.float16
+    shape = (len(cags), len(sample_names)),
+    dtype = np.float32,
+    columns = sample_names
 )
+
+# Iterate over each sample
+for sample_ix, sample_name in enumerate(sample_names):
+
+    # Read the depth of sequencing for each gene
+    logging.info("Reading gene abundances for %s" % sample_name)
+    sample_gene_depth = pd.Series(z[:, sample_ix], index=gene_names)
+
+    # Sum up the depth by CAG
+    df[sample_name] = pd.Series({
+        cag_ix: sample_gene_depth.reindex(index=cag_gene_list).sum()
+        for cag_ix, cag_gene_list in cags.items()
+    })
 
 max_dist = float("${params.distance_threshold}")
 logging.info("Maximum cosine distance: %s" % max_dist)
 
+# In the `iteratively_refine_cags` step, CAGs will be combined
+grouped_cags = {
+    cag_ix: [cag_ix]
+    for cag_ix in range(len(cags))
+}
+
 logging.info("Refining CAGS")
 iteratively_refine_cags(
-    cags,
+    grouped_cags,
     df.copy(),
     max_dist,
     threads=threads,
@@ -338,6 +332,16 @@ iteratively_refine_cags(
     max_iters = 5
 )
 
+logging.info("Expanding with the original set of CAGs")
+new_cags = {
+    cag_group_ix: [
+        gene_name
+        for original_cag in cag_group_list
+        for gene_name in cags[original_cag]
+    ]
+    for cag_group_ix, cag_group_list in grouped_cags.items()
+}
+
 logging.info("Formatting CAGs as a DataFrame")
 cags_df = pd.DataFrame(
     [
@@ -345,7 +349,7 @@ cags_df = pd.DataFrame(
         for ix, list_of_genes in enumerate(
             sorted(
                 list(
-                    cags.values()
+                    new_cags.values()
                 ), 
                 key=len, 
                 reverse=True

--- a/modules/make_cags.nf
+++ b/modules/make_cags.nf
@@ -79,7 +79,6 @@ with gzip.open("sample_names.json.gz", "rt") as handle:
 gene_list_csv = "${gene_list_csv}"
 
 # Make sure the files exist
-assert os.path.exists(details_hdf), details_hdf
 assert os.path.exists(gene_list_csv), gene_list_csv
 
 logging.info("Reading in the list of genes for this shard from %s" % (gene_list_csv))

--- a/modules/mmseqs.nf
+++ b/modules/mmseqs.nf
@@ -44,7 +44,7 @@ echo "Done"
 
 process diamondDedup {
     tag "Deduplicate sequences by alignment with DIAMOND"
-    container "quay.io/fhcrc-microbiome/famli@sha256:25c34c73964f06653234dd7804c3cf5d9cf520bc063723e856dae8b16ba74b0c"
+    container "quay.io/fhcrc-microbiome/famli:v1.5"
     label 'mem_veryhigh'
     errorStrategy 'retry'
     


### PR DESCRIPTION
The overall goal of this refactor is to make the CAG construction process much more efficient. The changes implemented for that goal are:

- Saving all gene abundances in Zarr format to speed up the process of reading subsets in each shard
- Grouping genes into CAGs before constructing each DataFrame to reduce the total memory burden
- Increasing the number of shards used to initiate the CAG construction by 10X