### PR TITLE
Shard size param

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -20,7 +20,7 @@
 */
 
 // Using DSL-2
-nextflow.enable.dsl=2
+nextflow.preview.dsl=2
 
 // Default values for boolean flags
 // If these are not set by the user, then they will be set to the values below

--- a/main.nf
+++ b/main.nf
@@ -20,7 +20,7 @@
 */
 
 // Using DSL-2
-nextflow.preview.dsl=2
+nextflow.enable.dsl=2
 
 // Default values for boolean flags
 // If these are not set by the user, then they will be set to the values below

--- a/main.nf
+++ b/main.nf
@@ -55,6 +55,7 @@ params.famli_batchsize = 10000000 // FAMLI
 params.famli_folder = false // Import FAMLI-filtered alignments
 
 // Annotation options
+params.gene_shard_size = 100000
 params.noannot = false
 params.taxonomic_dmnd = false
 params.tax_evalue = 0.00001
@@ -117,6 +118,7 @@ def helpMessage() {
     For Annotation:
       --noannot             If specified, disable annotation for taxonomy or function.
                             Individual annotations can also be disabled by, e.g., setting --eggnog_db false
+      --gene_shard_size     How many genes to include in a shard for annotation. (default: 100000)
       --taxonomic_dmnd      Database used for taxonomic annotation (default: false)
                             (Data available at s3://fh-ctr-public-reference-data/tool_specific_data/geneshot/2020-01-15-geneshot/DB.refseq.tax.dmnd)
       --tax_evalue          Maximum E-value threshold for taxonomic annotation by DIAMOND alignment

--- a/modules/assembly.nf
+++ b/modules/assembly.nf
@@ -7,6 +7,7 @@ params.output_prefix = "geneshot"
 params.tax_evalue = 0.00001
 params.gene_fasta = false
 params.assembly_folder = false
+params.gene_shard_size = 100000
 
 // Containers
 container__assembler = "quay.io/biocontainers/megahit:1.2.9--h8b12597_0"
@@ -521,7 +522,7 @@ process shard_genes {
 
 set -Eeuo pipefail
 
-split --additional-suffix .fasta -l 1000000 <(gunzip -c ${fasta_gz}) genes.shard.
+split --additional-suffix .fasta -l ${params.gene_shard_size} <(gunzip -c ${fasta_gz}) genes.shard.
 
 gzip genes.shard.*.fasta
 """


### PR DESCRIPTION
Correct issue #61. Adds a gene shard size parameter, and reduces the default to 100k.